### PR TITLE
Add uinfo and ufind

### DIFF
--- a/futaba/__init__.py
+++ b/futaba/__init__.py
@@ -14,13 +14,14 @@
 futaba - A Discord Mod bot for the Programming server
 '''
 
-from . import client, config, enums, permissions, utils
+from . import client, config, enums, parse, permissions, utils
 
 __all__ = [
     '__version__',
     'client',
     'config',
     'enums',
+    'parse',
     'permissions',
     'utils',
 ]

--- a/futaba/cogs/info/__init__.py
+++ b/futaba/cogs/info/__init__.py
@@ -1,5 +1,5 @@
 #
-# cogs/<cog folder name>/core.py
+# cogs/info/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
 # Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
@@ -10,24 +10,12 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-# pylint: skip-file
+from .core import Info
 
-'''
-<description>
-'''
-
-import asyncio
-import logging
-
-import discord
-from discord.ext import commands
-
-logger = logging.getLogger(__package__)
-
-class NameOfCog:
+def setup(bot):
     '''
-    <description>
+    Setup for bot to add cog
     '''
 
-    def __init__(self, bot):
-        self.bot = bot
+    cog = Info(bot)
+    bot.add_cog(cog)

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -73,7 +73,14 @@ class Info:
 
         logger.debug("Found user! %r", user)
 
-        embed = discord.Embed(description=user.mention)
+        # Status
+        if getattr(user, 'status', None):
+            status = 'do not disturb' if user.status == discord.Status.dnd else user.status
+            descr = f'{user.mention}, {status}'
+        else:
+            descr = user.mention
+
+        embed = discord.Embed(description=descr)
         embed.timestamp = user.created_at
         embed.set_author(name=f'{user.name}#{user.discriminator}')
         embed.set_thumbnail(url=user.avatar_url)
@@ -82,6 +89,7 @@ class Info:
         if hasattr(user, 'colour'):
             embed.colour = user.colour
 
+        # User id
         embed.add_field(name='ID:', value=f'`{user.id}`')
 
         # Roles

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -1,0 +1,142 @@
+#
+# cogs/info/core.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Informational commands that make finding and gathering data easier.
+'''
+
+import asyncio
+import logging
+import re
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+
+from futaba.enums import Reactions
+from futaba.parse import get_user_id
+from futaba.utils import fancy_timedelta
+
+logger = logging.getLogger(__package__)
+
+__all__ = [
+    'Info',
+]
+
+class Info:
+    '''
+    Cog for informational commands.
+    '''
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name='uinfo', aliases=['userinfo'])
+    async def uinfo(self, ctx, name: str = None):
+        '''
+        Fetch information about a user, whether they are in the guild or not.
+        If no argument is passed, the caller is checked instead.
+        '''
+
+        if name is None:
+            name = str(ctx.message.author.id)
+
+        logger.info("Running uinfo on '%s'", name)
+
+        id = get_user_id(name, self.bot.users)
+        if id is None:
+            logger.debug("No user ID found!")
+            await Reactions.FAIL.add(ctx.message)
+            return
+
+        logger.debug("Fetched user ID is %d", id)
+
+        user = None
+        if ctx.guild is not None:
+            user = ctx.guild.get_member(id)
+
+        if user is None:
+            user = self.bot.get_user(id)
+            if user is None:
+                logger.debug("No user with that ID found!")
+                await Reactions.FAIL.add(ctx.message)
+                return
+
+        logger.debug("Found user! %r", user)
+
+        embed = discord.Embed(description=user.mention)
+        embed.timestamp = user.created_at
+        embed.set_author(name=f'{user.name}#{user.discriminator}')
+        embed.set_thumbnail(url=user.avatar_url)
+
+        # User colour
+        if hasattr(user, 'colour'):
+            embed.colour = user.colour
+
+        embed.add_field(name='ID:', value=f'`{user.id}`')
+
+        # Roles
+        if getattr(user, 'roles', None):
+            roles = ' '.join(role.mention for role in user.roles[1:])
+            if roles:
+                embed.add_field(name='Roles:', value=roles)
+
+        # Current game
+        if getattr(user, 'activity', None):
+            act = user.activity
+            if isinstance(act, discord.Game):
+                if act.start is None:
+                    if act.end is None:
+                        time_msg = ''
+                    else:
+                        time_msg = f'until {act.end}'
+                else:
+                    if act.end is None:
+                        time_msg = f'since {act.start}'
+                    else:
+                        time_msg = f'from {act.start} to {act.end}'
+
+                embed.description += f'\nPlaying `{act.name}` {time_msg}'
+            elif isinstance(act, discord.Streaming):
+                embed.description += f'\nStreaming [{act.name}]({act.url})'
+                if act.details is not None:
+                    embed.description += f'\n{act.details}'
+            elif isinstance(act, discord.Activity):
+                embed.description += '\n{act.state} [{act.name}]({act.url})'
+
+        # Voice activity
+        if getattr(user, 'voice', None):
+            mute = user.voice.mute or user.voice.self_mute
+            deaf = user.voice.deaf or user.voice.self_deaf
+
+            states = []
+            if mute:
+                states.append('muted')
+            if deaf:
+                states.append('deafened')
+
+            if states:
+                state = ', '.join(states)
+            else:
+                state = 'active'
+
+            embed.add_field(name='Voice:', value=state)
+
+        # Join date
+        if hasattr(user, 'joined_at'):
+            embed.add_field(name='Member for:', value=fancy_timedelta(user.joined_at))
+
+        # Send them
+        await asyncio.gather(
+            Reactions.SUCCESS.add(ctx.message),
+            ctx.send(embed=embed),
+        )

--- a/futaba/parse.py
+++ b/futaba/parse.py
@@ -79,10 +79,10 @@ def role_mention(mention):
 
     return int(match[1])
 
-def name_discrim_search(name, users=(), ignorecase=False):
+def name_discrim_search(name, users):
     '''
     Searches for a user matching the string [username]#[discriminator].
-    If ignorecase is True then the usernames are compared without regard to case.
+    It searches case-insensitively.
     '''
 
     match = USERNAME_DISCRIM_REGEX.match(name)
@@ -90,11 +90,14 @@ def name_discrim_search(name, users=(), ignorecase=False):
         return None
 
     name, discrim = match[1], int(match[2])
-    if ignorecase:
-        name = normalize_caseless(name)
-        return discord.utils.find(lambda u: name == normalize_caseless(u.name) and discrim == u.discriminator)
-    else:
-        return discord.utils.get(users, name=name, discriminator=discrim)
+    def check(user):
+        uname = normalize_caseless(user.name)
+        udiscrim = user.discriminator
+
+        return name == uname and discrim == udiscrim
+
+    name = normalize_caseless(name)
+    return discord.utils.find(check, users)
 
 def similar_names(word1, word2):
     '''
@@ -127,7 +130,7 @@ def get_user_id(name, users=()):
 
     # Check by name#discrim
     logger.debug("get_user_id: checking if it's a username#discriminator")
-    user = name_discrim_search(name, users, True)
+    user = name_discrim_search(name, users)
     if user is not None:
         return user.id
 
@@ -179,7 +182,7 @@ def similar_user_ids(name, users, max_entries=5):
 
     # Check by name#discrim
     logger.debug("similar_user_ids: checking if it's a username#discriminator")
-    user = name_discrim_search(name, users, True)
+    user = name_discrim_search(name, users)
     if user is not None:
         matching_ids.append(user.id)
 

--- a/futaba/parse.py
+++ b/futaba/parse.py
@@ -28,7 +28,7 @@ __all__ = [
 ]
 
 CHANNEL_MENTION_REGEX = re.compile(r'<#([0-9]+)>')
-USER_MENTION_REGEX = re.compile(r'<@([0-9]+)>')
+USER_MENTION_REGEX = re.compile(r'<@!?([0-9]+)>')
 ROLE_MENTION_REGEX = re.compile(r'<@&([0-9]+)>')
 USERNAME_DISCRIM_REGEX = re.compile(r'(.+)#([0-9]{4})')
 

--- a/futaba/parse.py
+++ b/futaba/parse.py
@@ -1,0 +1,132 @@
+#
+# discord.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+import logging
+import re
+
+import discord
+
+from futaba.utils import normalize_caseless
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'channel_mention',
+    'user_mention',
+    'role_mention',
+    'name_discrim_search',
+    'get_user_id',
+]
+
+CHANNEL_MENTION_REGEX = re.compile(r'<#([0-9]+)>')
+USER_MENTION_REGEX = re.compile(r'<@([0-9]+)>')
+ROLE_MENTION_REGEX = re.compile(r'<@&([0-9]+)>')
+USERNAME_DISCRIM_REGEX = re.compile(r'(.+)#([0-9]{4})')
+
+def channel_mention(mention):
+    '''
+    Parses a channel mention, returning the ID inside.
+    The id might not correspond with an actual channel.
+    '''
+
+    logger.debug("Checking possible channel mention '%s'", mention)
+
+    match = CHANNEL_MENTION_REGEX.match(mention)
+    if match is None:
+        return None
+
+    return int(match[1])
+
+def user_mention(mention):
+    '''
+    Parses a user mention, returning the ID inside.
+    The id might not correspond with an actual user.
+    '''
+
+    logger.debug("Checking possible user mention '%s'", mention)
+
+    match = USER_MENTION_REGEX.match(mention)
+    if match is None:
+        return None
+
+    return int(match[1])
+
+def role_mention(mention):
+    '''
+    Parses the role mention, returning the ID insice.
+    The id might not correspond with an actual role.
+    Does not work on @everyone or @here pings.
+    '''
+
+    logger.debug("Checking possible role mention '%s'", mention)
+
+    match = ROLE_MENTION_REGEX.match(mention)
+    if match is None:
+        return None
+
+    return int(match[1])
+
+def name_discrim_search(s, users=(), ignorecase=False):
+    match = USERNAME_DISCRIM_REGEX.match(s)
+    if match is None:
+        return None
+
+    name, discrim = match[1], int(match[2])
+    if ignorecase:
+        name = normalize_caseless(name)
+        return discord.utils.find(lambda u: name == normalize_caseless(u.name) and discrim == u.discriminator)
+    else:
+        return discord.utils.get(users, name=name, discriminator=discrim)
+
+def get_user_id(name, users=()):
+    # Allow case-insensitive searching
+    name = normalize_caseless(name)
+
+    # Check for user ID
+    logger.debug("get_user_id: checking if it's an integer")
+    if name.isdigit():
+        return int(name)
+
+    # Check for mention
+    logger.debug("get_user_id: checking if it's a user mention")
+    id = user_mention(name)
+    if id is not None:
+        return id
+
+    # Check by name#discrim
+    logger.debug("get_user_id: checking if it's a username#discriminator")
+    user = name_discrim_search(name, users, True)
+    if user is not None:
+        return user.id
+
+    # Check by username
+    logger.debug("get_user_id: checking if it's a username")
+    user = discord.utils.get(users, name=name)
+    if user is not None:
+        return user.id
+
+    # Check by nickname
+    def check_user(user):
+        nick = getattr(user, 'nick', None)
+        if nick is None:
+            return False
+
+        return name == normalize_caseless(nick)
+
+    logger.debug("get_user_id: checking if it's a nickname")
+    user = discord.utils.find(check_user, users)
+    if user is not None:
+        return user.id
+
+    # No results
+    logger.debug("get_user_id found no results!")
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/Rapptz/discord.py@rewrite#egg=discord.py
 SQLAlchemy>=1.0
 confusable_homoglyphs>=3.0
+textdistance>=3.0
 toml>=0.9


### PR DESCRIPTION
This adds the `info` cog, and adds two commands for searching users.

`uinfo` is for getting information about users, including those not in the guild. If they are members, it also provides information about their voice state, roles, etc.

`ufind` is for fuzzy searching among all known users. It accepts misspellings and other changes, as well as the normal methods of naming users like by ID and mention.

The means used to produce this information is available in the new `parse` module, so that other parts of the codebase can also use the function to conveniently provide fuzzy or easy `discord.User` fetching.