### PR TITLE
Add journalling support to the bot

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/futaba/__init__.py
+++ b/futaba/__init__.py
@@ -14,13 +14,14 @@
 futaba - A Discord Mod bot for the Programming server
 '''
 
-from . import client, config, enums, parse, permissions, utils
+from . import client, config, enums, journal, parse, permissions, utils
 
 __all__ = [
     '__version__',
     'client',
     'config',
     'enums',
+    'journal',
     'parse',
     'permissions',
     'utils',

--- a/futaba/__init__.py
+++ b/futaba/__init__.py
@@ -2,7 +2,7 @@
 # __init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/__main__.py
+++ b/futaba/__main__.py
@@ -24,6 +24,7 @@ from . import client
 from .config import InvalidConfigError, load_config
 
 LOG_FILE = 'futaba.log'
+LOG_JOURNAL_FILE = 'futaba-journal.log'
 LOG_FILE_MODE = 'w'
 LOG_FORMAT = '[%(levelname)s] %(asctime)s %(name)s: %(message)s'
 LOG_DATE_FORMAT = '[%d/%m/%Y %H:%M:%S]'
@@ -40,6 +41,9 @@ if __name__ == '__main__':
     argparser.add_argument('-D', '--discord',
                            dest='discord_log', action='store_true',
                            help="Adds the Discord logger to the log file.")
+    argparser.add_argument('-J', '--no-journal',
+                            dest='journal_log', action='store_false',
+                            help="Adds the special Futaba journal logger to the journal log file.")
     argparser.add_argument('config_file',
                            help="Specify a configuration file to use. Keep it secret!")
     args = argparser.parse_args()
@@ -53,6 +57,14 @@ if __name__ == '__main__':
     logger = logging.getLogger(__package__)
     logger.setLevel(level=log_level)
     logger.addHandler(log_hndl)
+
+    if args.journal_log:
+        log_journal_hndl = logging.FileHandler(filename=LOG_JOURNAL_FILE, encoding='utf-8', mode=LOG_FILE_MODE)
+        log_journal_hndl.setFormatter(log_fmtr)
+
+        journal_logger = logging.getLogger('futaba.meta.journal')
+        journal_logger.setLevel(level=logging.DEBUG)
+        journal_logger.addHandler(log_journal_hndl)
 
     if args.discord_log:
         discord_logger = logging.getLogger('discord')

--- a/futaba/__main__.py
+++ b/futaba/__main__.py
@@ -2,7 +2,7 @@
 # __main__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/__main__.py
+++ b/futaba/__main__.py
@@ -68,11 +68,11 @@ if __name__ == '__main__':
 
     try:
         config = load_config(args.config_file)
-    except (TomlDecodeError, IOError) as err:
-        logger.error("Unable to read configuration file.", exc_info=err)
+    except (TomlDecodeError, IOError) as error:
+        logger.error("Unable to read configuration file.", exc_info=error)
         exit(1)
-    except InvalidConfigError as err:
-        logger.error("Error when processing configuration file: %s", err)
+    except InvalidConfigError as error:
+        logger.error("Error when processing configuration file: %s", error)
         exit(1)
 
     # Open and run client

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -21,7 +21,7 @@ import os
 import discord
 from discord.ext import commands
 
-#from .cogs.journal import Journal
+from .cogs.journal import Journal
 from .cogs.reloader import Reloader
 from .config import Configuration
 from .enums import Reactions
@@ -89,8 +89,8 @@ class Bot(commands.AutoShardedBot):
             self.debug_chan = self.get_channel(int(self.config.debug_channel_id))
 
         # Setup mandatory cogs
-        #self.add_cog(Journal(self))
-        #logger.info("Loaded mandatory cog: Journal")
+        self.add_cog(Journal(self))
+        logger.info("Loaded mandatory cog: Journal")
 
         self.add_cog(Reloader(self))
         logger.info("Loaded mandatory cog: Reloader")

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -58,9 +58,8 @@ class Bot(commands.AutoShardedBot):
 
     @property
     def uptime(self):
-        '''
-        Gets the uptime for the bot
-        '''
+        ''' Gets the bot's uptime '''
+
         return datetime.datetime.utcnow() - self.start_time
 
     def run_with_token(self):

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -2,7 +2,7 @@
 # client.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -101,7 +101,7 @@ class Bot(commands.AutoShardedBot):
                 return False
 
             # Check for mandatory cogs
-            if cog in ('journal', 'reloader'):
+            if cog in Reloader.MANDATORY_COGS:
                 return False
 
             # Cog is a directory

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -25,7 +25,7 @@ from .cogs.journal import Journal
 from .cogs.reloader import Reloader
 from .config import Configuration
 from .enums import Reactions
-from .journal import LoggingOutputListener
+from .journal import Broadcaster, LoggingOutputListener
 from .sql import SqlHandler
 from .utils import plural
 
@@ -139,6 +139,13 @@ class Bot(commands.AutoShardedBot):
         logger.info("* %d users", len(self.users))
         logger.info("------")
         logger.info("Ready!")
+
+    def get_broadcaster(self, root):
+        '''
+        A utility method for instantiating a bound Broadcaster on the given path.
+        '''
+
+        return Broadcaster(self.journal_cog.router, root)
 
     async def on_guild_join(self, guild):
         '''

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -21,10 +21,12 @@ import os
 import discord
 from discord.ext import commands
 
+#from .cogs.journal import Journal
+from .cogs.reloader import Reloader
 from .config import Configuration
 from .enums import Reactions
 from .sql import SqlHandler
-from .utils import Reloader, plural
+from .utils import plural
 
 logger = logging.getLogger(__name__)
 
@@ -86,12 +88,24 @@ class Bot(commands.AutoShardedBot):
         else:
             self.debug_chan = self.get_channel(int(self.config.debug_channel_id))
 
-        # Setup cog loading
+        # Setup mandatory cogs
+        #self.add_cog(Journal(self))
+        #logger.info("Loaded mandatory cog: Journal")
+
         self.add_cog(Reloader(self))
-        logger.info("Loaded cog: Reloader")
+        logger.info("Loaded mandatory cog: Reloader")
 
         def _cog_ok(cog):
-            return not cog.startswith('_') and os.path.isdir(f'futaba/cogs/{cog}')
+            # Special files
+            if cog.startswith('_'):
+                return False
+
+            # Check for mandatory cogs
+            if cog in ('journal', 'reloader'):
+                return False
+
+            # Cog is a directory
+            return os.path.isdir(f'futaba/cogs/{cog}')
 
         files = [cog for cog in os.listdir('futaba/cogs') if _cog_ok(cog)]
         logger.info("Cogs found: %s", ', '.join(files))

--- a/futaba/cogs/__init__.py
+++ b/futaba/cogs/__init__.py
@@ -2,7 +2,7 @@
 # cogs/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/_core.py
+++ b/futaba/cogs/_core.py
@@ -2,7 +2,7 @@
 # cogs/<cog folder name>/core.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/filter/__init__.py
+++ b/futaba/cogs/filter/__init__.py
@@ -2,7 +2,7 @@
 # cogs/filter/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/filter/check.py
+++ b/futaba/cogs/filter/check.py
@@ -12,18 +12,32 @@
 
 import asyncio
 import logging
+from collections import namedtuple
 
 import discord
 
 from futaba.enums import FilterType, LocationType
 from futaba.utils import Dummy, escape_backticks
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     'check_message',
     'check_message_edit',
 ]
 
-logger = logging.getLogger(__name__)
+JournalProperties = namedtuple('JournalProperties', ('verb', 'path', 'icon'))
+
+JOURNAL_PROPERTIES = {
+    FilterType.FLAG: JournalProperties(verb='Flagged', path='flag', icon='flag'),
+    FilterType.BLOCK: JournalProperties(verb='Blocked', path='block', icon='deleted'),
+    FilterType.JAIL: JournalProperties(verb='Jailed for', path='jail', icon='jail'),
+}
+
+def journal_violation(journal, message, filter_type, flagged_content):
+    props = JOURNAL_PROPERTIES[filter_type]
+    content = f'{props.verb} message content: `{flagged_content}` by {message.author.mention} in {message.channel.mention}'
+    journal.send(props.path, message.guild, content, icon=props.icon)
 
 async def check_message(cog, message):
     '''
@@ -74,6 +88,7 @@ async def check_message(cog, message):
         for filter_text, (filter, filter_type) in all_filters.items():
             if filter.matches(content):
                 await found_violation(
+                    cog.journal,
                     message,
                     content,
                     location_type,
@@ -127,7 +142,7 @@ def filter_immune(bot, message):
 
     return False
 
-async def found_violation(message, content, location_type, filter_type, filter_text):
+async def found_violation(journal, message, content, location_type, filter_type, filter_text):
     '''
     Processes a violation of the text filter. This method is responsible
     for actual enforcement, based on the filter_type.
@@ -140,13 +155,14 @@ async def found_violation(message, content, location_type, filter_type, filter_t
     jail_role = Dummy() # FIXME
     jail_role.name = 'Dunce Hat'
 
+    # Escape content for display
+    escaped_filter_text = escape_backticks(filter_text)
+    escaped_content = escape_backticks(content)
+
+    if len(escaped_content) > 1800:
+        escaped_content = escaped_content[:1800] + ' ... (message too long)'
+
     async def message_violator():
-        escaped_filter_text = escape_backticks(filter_text)
-        escaped_content = escape_backticks(content)
-
-        if len(escaped_content) > 1800:
-            escaped_content = escaped_content[:1800] + ' ... (message too long)'
-
         logger.debug("Sending message to user who violated the filter")
         lines = [
             f"The message you posted in {message.channel.mention} violates a {location_type.value} "
@@ -184,9 +200,8 @@ async def found_violation(message, content, location_type, filter_type, filter_t
         await message.author.send(content='\n'.join(lines))
 
     if severity >= FilterType.FLAG.level:
-        # TODO notify staff
-        # this requires the logging cog to be complete
         logger.info("Notifying staff of filter violation")
+        journal_violation(journal, message, filter_type, escaped_content)
 
     if severity >= FilterType.BLOCK.level:
         logger.info("Deleting inappropriate message id %d and notifying user", message.id)

--- a/futaba/cogs/filter/check.py
+++ b/futaba/cogs/filter/check.py
@@ -2,7 +2,7 @@
 # cogs/filter/check.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/filter/check.py
+++ b/futaba/cogs/filter/check.py
@@ -16,7 +16,7 @@ import logging
 import discord
 
 from futaba.enums import FilterType, LocationType
-from futaba.utils import Dummy
+from futaba.utils import Dummy, escape_backticks
 
 __all__ = [
     'check_message',
@@ -141,8 +141,8 @@ async def found_violation(message, content, location_type, filter_type, filter_t
     jail_role.name = 'Dunce Hat'
 
     async def message_violator():
-        escaped_filter_text = filter_text.replace('`', '\N{ARMENIAN COMMA}')
-        escaped_content = content.replace('`', '\N{ARMENIAN COMMA}')
+        escaped_filter_text = escape_backticks(filter_text)
+        escaped_content = escape_backticks(content)
 
         if len(escaped_content) > 1800:
             escaped_content = escaped_content[:1800] + ' ... (message too long)'

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -2,7 +2,7 @@
 # cogs/filter/core.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -24,7 +24,7 @@ from discord.ext import commands
 
 from futaba import permissions
 from futaba.enums import FilterType, Reactions
-from futaba.utils import async_partial
+from futaba.utils import async_partial, escape_backticks
 from .check import check_message, check_message_edit
 from .filter import Filter
 from .manage import add_filter, delete_filter, show_filter
@@ -38,6 +38,7 @@ __all__ = [
 class Filtering:
     __slots__ = (
         'bot',
+        'journal',
         'filters',
         'check_message',
         'check_message_edit',
@@ -45,6 +46,7 @@ class Filtering:
 
     def __init__(self, bot):
         self.bot = bot
+        self.journal = bot.get_broadcaster('/filter')
         self.filters = defaultdict(dict)
         self.check_message = async_partial(check_message, self)
         self.check_message_edit = async_partial(check_message_edit, self)
@@ -103,12 +105,6 @@ class Filtering:
             # TODO send help
             await Reactions.FAIL.add(ctx.message)
 
-    @filter.command(name='hello', aliases=['greetings'])
-    @commands.guild_only()
-    async def hello(self, ctx, *members: discord.Member):
-        # TEMP debugging discord.Member
-        await ctx.send(content=f"Hello! {', '.join(member.name for member in members)}")
-
     @filter_immunity.command(name='add', aliases=['append', 'extend', 'new'])
     @commands.guild_only()
     @permissions.check_admin()
@@ -129,6 +125,10 @@ class Filtering:
             for member in members:
                 logger.debug("Adding member: %s (%d)", member.display_name, member.id)
                 self.bot.sql.filter.add_filter_immune_user(ctx.guild, member)
+
+        for member in members:
+            content = f'Added {member.name}#{member.discriminator} to filter immunity list'
+            self.journal.send('immunity/new', ctx.guild, content, icon='person')
 
         await Reactions.SUCCESS.add(ctx.message)
 
@@ -152,6 +152,10 @@ class Filtering:
             for member in members:
                 logger.debug("Removing member: %s (%d)", member.display_name, member.id)
                 self.bot.sql.filter.remove_filter_immune_user(ctx.guild, member)
+
+        for member in members:
+            content = f'Removed {member.name}#{member.discriminator} from filter immunity list'
+            self.journal.send('immunity/remove', ctx.guild, content, icon='person')
 
         await Reactions.SUCCESS.add(ctx.message)
 
@@ -196,17 +200,6 @@ class Filtering:
 
         await show_filter(self.filters[ctx.guild], ctx.message, ctx.author, ctx.guild.name)
 
-    @filter_guild.command(name='remove', aliases=['rm', 'delete', 'del'])
-    @commands.guild_only()
-    @permissions.check_mod()
-    async def filter_guild_remove(self, ctx, *, text: str):
-        '''
-        Removes the given string from the server-wide filter.
-        You don't need to tell it which filter level it was for.
-        '''
-
-        await delete_filter(self.bot, self.filters, ctx.message, ctx.guild, text)
-
     @filter_guild.command(name='flag', aliases=['warn', 'alert', 'notice'])
     @commands.guild_only()
     @permissions.check_mod()
@@ -219,6 +212,8 @@ class Filtering:
         a single word to add to the filter.
         '''
 
+        content = f'Added guild flag filter for `{escape_backticks(text)}`'
+        self.journal.send('guild/new/flag', ctx.guild, content, icon='filter')
         await add_filter(self.bot, self.filters, ctx.message, ctx.guild, FilterType.FLAG, text)
 
     @filter_guild.command(name='block', aliases=['deny', 'autoremove'])
@@ -233,6 +228,8 @@ class Filtering:
         a single word to add to the filter.
         '''
 
+        content = f'Added guild block filter for `{escape_backticks(text)}`'
+        self.journal.send('guild/new/block', ctx.guild, content, icon='filter')
         await add_filter(self.bot, self.filters, ctx.message, ctx.guild, FilterType.BLOCK, text)
 
     @filter_guild.command(name='jail', aliases=['dunce', 'punish', 'mute'])
@@ -247,7 +244,22 @@ class Filtering:
         a single word to add to the filter.
         '''
 
+        content = f'Added guild jail filter for `{escape_backticks(text)}`'
+        self.journal.send('guild/new/jail', ctx.guild, content, icon='filter')
         await add_filter(self.bot, self.filters, ctx.message, ctx.guild, FilterType.JAIL, text)
+
+    @filter_guild.command(name='remove', aliases=['rm', 'delete', 'del'])
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def filter_guild_remove(self, ctx, *, text: str):
+        '''
+        Removes the given string from the server-wide filter.
+        You don't need to tell it which filter level it was for.
+        '''
+
+        content = f'Removed guild filter for `{escape_backticks(text)}`'
+        self.journal.send('guild/remove', ctx.guild, content, icon='filter')
+        await delete_filter(self.bot, self.filters, ctx.message, ctx.guild, text)
 
     @filter.group(name='channel', aliases=['chan', 'ch', 'c'])
     @commands.guild_only()
@@ -281,6 +293,8 @@ class Filtering:
         a single word to add to the filter.
         '''
 
+        content = f'Added channel flag filter in {channel.mention} for `{escape_backticks(text)}`'
+        self.journal.send('channel/new/flag', ctx.guild, content, icon='filter')
         await add_filter(self.bot, self.filters, ctx.message, channel, FilterType.FLAG, text)
 
     @filter_channel.command(name='block', aliases=['deny', 'autoremove'])
@@ -295,6 +309,8 @@ class Filtering:
         a single word to add to the filter.
         '''
 
+        content = f'Added channel block filter in {channel.mention} for `{escape_backticks(text)}`'
+        self.journal.send('channel/new/block', ctx.guild, content, icon='filter')
         await add_filter(self.bot, self.filters, ctx.message, channel, FilterType.BLOCK, text)
 
     @filter_channel.command(name='jail', aliases=['dunce', 'punish', 'mute'])
@@ -309,6 +325,8 @@ class Filtering:
         a single word to add to the filter.
         '''
 
+        content = f'Added channel jail filter in {channel.mention} for `{escape_backticks(text)}`'
+        self.journal.send('channel/new/jail', ctx.guild, content, icon='filter')
         await add_filter(self.bot, self.filters, ctx.message, channel, FilterType.JAIL, text)
 
     @filter_channel.command(name='remove', aliases=['rm', 'delete', 'del'])
@@ -320,4 +338,6 @@ class Filtering:
         tell it which filter level it was for.
         '''
 
+        content = f'Removed channel filter in {channel.mention} for `{escape_backticks(text)}`'
+        self.journal.send('channel/remove', ctx.guild, content, icon='filter')
         await delete_filter(self.bot, self.filters, ctx.message, channel, text)

--- a/futaba/cogs/filter/filter.py
+++ b/futaba/cogs/filter/filter.py
@@ -2,7 +2,7 @@
 # cogs/filter/filter.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/filter/manage.py
+++ b/futaba/cogs/filter/manage.py
@@ -2,7 +2,7 @@
 # cogs/filter/manage.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/info/__init__.py
+++ b/futaba/cogs/info/__init__.py
@@ -2,7 +2,7 @@
 # cogs/info/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -2,7 +2,7 @@
 # cogs/info/core.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/journal/__init__.py
+++ b/futaba/cogs/journal/__init__.py
@@ -2,7 +2,7 @@
 # cogs/journal/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/journal/__init__.py
+++ b/futaba/cogs/journal/__init__.py
@@ -1,0 +1,21 @@
+#
+# cogs/journal/__init__.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+from .core import Journal
+
+def setup(bot):
+    '''
+    Setup for bot to add cog
+    '''
+
+    cog = Journal(bot)
+    bot.add_cog(cog)

--- a/futaba/cogs/journal/__init__.py
+++ b/futaba/cogs/journal/__init__.py
@@ -11,6 +11,7 @@
 #
 
 from .core import Journal
+from .tracking import Tracking, LISTENERS
 
 def setup(bot):
     '''
@@ -18,4 +19,9 @@ def setup(bot):
     '''
 
     cog = Journal(bot)
+    bot.add_cog(cog)
+
+    cog = Tracking(bot)
+    for listener in LISTENERS:
+        bot.add_listener(getattr(cog, listener), listener)
     bot.add_cog(cog)

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -45,8 +45,10 @@ class Journal:
         logger.info("Loading journal output channels from the database")
         with bot.sql.transaction():
             for guild in bot.guilds:
-                bot.sql.journal.get_journal_channels(guild)
-
+                for output in bot.sql.journal.get_journal_channels(guild):
+                    logger.info("Registering journal channel #%s (%d) for path '%s'",
+                            output.channel.name, output.channel.id, output.path)
+                    self.router.register(ChannelOutputListener(self.router, output.path, output.channel))
         self.router.start(bot.loop)
 
     @commands.group(name='journal', aliases=['log'])

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -2,7 +2,7 @@
 # cogs/journal/core.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -40,6 +40,7 @@ class Journal:
     def __init__(self, bot):
         self.bot = bot
         self.router = Router()
+        bot.journal_cog = self
 
         logger.info("Loading journal output channels from the database")
         with bot.sql.transaction():

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -1,0 +1,95 @@
+#
+# cogs/journal/core.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Cog for configuring Futaba journalling output, directing certain kinds
+of messages to different logging channels.
+'''
+
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from futaba import permissions
+from futaba.enums import Reactions
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'Journal',
+]
+
+class Journal:
+    __slots__ = (
+        'bot',
+    )
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.group(name='journal', aliases=['log'])
+    async def log(self, ctx):
+        ''' Configure channel output for bot journal events. '''
+
+        if ctx.invoked_subcommand is None:
+            # TODO send help
+            await Reactions.FAIL.add(ctx.message)
+
+    @log.command(name='show', aliases=['display', 'list'])
+    @commands.guild_only()
+    @permissions.check_admin()
+    async def log_show(self, ctx):
+        ''' Displays current settings for this guild '''
+
+        # TODO store settings in DB
+        # TODO retrieve settings on load
+        # TODO allow per-guild querying
+        # TODO add logging.info() calls to commands
+        await Reactions.FAIL.add(ctx.message)
+
+    @log.command(name='add', aliases=['append', 'extend', 'new'])
+    @commands.guild_only()
+    @permissions.check_admin()
+    async def log_add(self, ctx, channel: discord.TextChannel, path: str, *flags: str):
+        '''
+        Add a journal logger to the channel for the given path.
+        Accepts the optional flags:
+            -exact, Don't recursively accept journal events from children.
+        '''
+
+        recursive = True
+
+        for flag in flags:
+            if flag == '-exact':
+                recursive = False
+            else:
+                await asyncio.gather(
+                    Reactions.FAIL.add(ctx.message),
+                    ctx.send(content=f'No such flag: {flag}')
+                )
+                return
+
+        # TODO add
+        await Reactions.FAIL.add(ctx.message)
+
+    @log.command(name='remove', aliases=['rm', 'delete', 'del'])
+    @commands.guild_only()
+    @permissions.check_admin()
+    async def log_remove(self, ctx, channel: discord.TextChannel, path: str):
+        '''
+        Removes a journal logger for the given path from the channel.
+        '''
+
+        # TODO remove
+        await Reactions.FAIL.add(ctx.message)

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -161,16 +161,16 @@ class Journal:
             return
 
         journal_attributes = {}
-        try:
-            for attribute in attributes:
-                for key, value in attribute.split('='):
-                    journal_attributes[key] = value
-        except ValueError:
-            await asyncio.gather(
-                ctx.send(content='All attributes must be in the form KEY=VALUE'),
-                Reactions.FAIL.add(ctx.message),
-            )
-            return
+        for attribute in attributes:
+            try:
+                key, value = attribute.split('=')
+                journal_attributes[key] = value
+            except ValueError:
+                await asyncio.gather(
+                    ctx.send(content='All attributes must be in the form KEY=VALUE'),
+                    Reactions.FAIL.add(ctx.message),
+                )
+                return
 
         logging.info("Sending manual journal event: '%s' (attrs: %s)", content, journal_attributes)
-        self.bot.get_broadcaster(path).send(content, **journal_attributes)
+        self.bot.get_broadcaster(path).send('', ctx.guild, content, **journal_attributes)

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -70,10 +70,11 @@ class Journal:
             if not output.settings.recursive:
                 attributes.append('exact path')
 
-            lines.append(f'- `{output.path}` mounted on {output.channel.mention} {", ".join(attributes)}')
+            attributes_str = f'({", ".join(attributes)})' if attributes else ''
+            lines.append(f'- `{output.path}` mounted at {output.channel.mention} {attributes_str}')
             attributes.clear()
 
-        if len(lines) > 1:
+        if lines:
             embed = discord.Embed(colour=discord.Colour.teal(), description='\n'.join(lines))
             embed.set_author(name='Current journal outputs')
         else:
@@ -85,7 +86,7 @@ class Journal:
             Reactions.SUCCESS.add(ctx.message),
         )
 
-    @log.command(name='add', aliases=['append', 'extend', 'new'])
+    @log.command(name='add', aliases=['append', 'extend', 'new', 'set', 'update'])
     @commands.guild_only()
     @permissions.check_mod()
     async def log_add(self, ctx, channel: discord.TextChannel, path: str, *flags: str):
@@ -134,6 +135,6 @@ class Journal:
                 channel.name, channel.id, path)
 
         with self.bot.sql.transaction():
-            self.bot.sql.delete_journal_channel(channel, path)
+            self.bot.sql.journal.delete_journal_channel(channel, path)
 
         await Reactions.SUCCESS.add(ctx.message)

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -46,7 +46,7 @@ class Journal:
             for guild in bot.guilds:
                 bot.sql.journal.get_journal_channels(guild)
 
-        self.router.start(bot.eventloop)
+        self.router.start(bot.loop)
 
     @commands.group(name='journal', aliases=['log'])
     async def log(self, ctx):

--- a/futaba/cogs/journal/tracking.py
+++ b/futaba/cogs/journal/tracking.py
@@ -1,0 +1,144 @@
+#
+# cogs/journal/tracking.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Cog for journaling live API events such as username changes, users joining and leaving, etc.
+'''
+
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from futaba import permissions
+from futaba.enums import Reactions
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'LISTENERS',
+    'Tracking',
+]
+
+LISTENERS = (
+    'on_typing',
+    'on_message',
+    'on_message_edit',
+    'on_message_delete',
+    'on_reaction_add',
+    'on_reaction_remove',
+    'on_reaction_clear',
+    'on_guild_channel_create',
+    'on_guild_channel_delete',
+)
+
+def user_discrim(user):
+    return f'{user.name}#{user.discriminator} ({user.id})'
+
+class Tracking:
+    __slots__ = (
+        'bot',
+        'journal',
+    )
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.journal = bot.get_broadcaster('/tracking')
+
+    def __unload(self):
+        '''
+        Remove listeners when unloading the cog.
+        '''
+
+        for listener in LISTENERS:
+            self.bot.remove_listener(getattr(self, listener), listener)
+
+    async def on_typing(self, channel, user, when):
+        if channel.guild is None:
+            return
+
+        logger.debug("Received typing event from %s (%d) in #%s (%d)",
+                user.name, user.id, channel.name, channel.id)
+
+        content = f'{user.name}#{user.discriminator} ({user.id}) is typing in {channel.mention}'
+        self.journal.send('typing', channel.guild, content, icon='typing')
+
+    async def on_message(self, message):
+        if message.guild is None:
+            return
+
+        logger.debug("Received message from %s (%d) in #%s (%d)",
+                message.author.name, message.author.id, message.channel.name, message.channel.id)
+
+        content = f'{user_discrim(message.author)} sent a message in {message.channel.mention}'
+        self.journal.send('message/new', message.guild, content, icon='message')
+
+    async def on_message_edit(self, before, after):
+        if after.guild is None:
+            return
+
+        logger.debug("Message %d by %s (%d) in #%s (%d) was edited",
+                after.id, after.author.name, after.author.id, after.channel.name, after.channel.id)
+
+        content = f'{user_discrim(after.author)} edited message {after.id} in {after.channel.mention}'
+        self.journal.send('message/edit', after.guild, content, icon='edit')
+
+    async def on_message_delete(self, message):
+        if message.guild is None:
+            return
+
+        logger.debug("Message %d by %s (%d) was deleted", message.id, message.author.name, message.author.id)
+        content = f'Message {message.id} by {user_discrim(message.author)} was deleted'
+        self.journal.send('message/delete', message.guild, content, icon='delete')
+
+    async def on_reaction_add(self, reaction, user):
+        message = reaction.message
+        channel = message.channel
+        emoji = reaction.emoji
+
+        if message.guild is None:
+            return
+
+        logger.debug("Reaction %s added to message %d by %s (%d)", emoji, message.id, user.name, user.id)
+        content = f'{user_discrim(user)} added reaction {emoji} to message {message.id} in {channel.mention}'
+        self.journal.send('reaction/add', message.guild, content, icon='item_add')
+
+    async def on_reaction_remove(self, reaction, user):
+        message = reaction.message
+        channel = message.channel
+        emoji = reaction.emoji
+
+        if message.guild is None:
+            return
+
+        logger.debug("Reaction %s removed to message %d by %s (%d)", emoji, message.id, user.name, user.id)
+        content = f'{user_discrim(user)} removed reaction {emoji} from message {message.id} in {channel.mention}'
+        self.journal.send('reaction/remove', message.guild, content, icon='item_remove')
+
+    async def on_reaction_clear(self, message, reactions):
+        if message.guild is None:
+            return
+
+        logger.debug("All reactions from message %d were removed", message.id)
+        content = f'All reactions on message {message.id} in {message.channel.mention} were removed'
+        self.journal.send('reaction/clear', message.guild, content, icon='item_clear')
+
+    async def on_guild_channel_create(self, channel):
+        logger.debug("Channel #%s (%d) was created", channel.name, channel.id)
+        content = f'Guild channel {channel.mention} created'
+        self.journal.send('channel/new', channel.guild, content, icon='channel')
+
+    async def on_guild_channel_delete(self, channel):
+        logger.debug("Channel #%s (%d) was deleted", channel.name, channel.id)
+        content = f'Guild channel #{channel.name} ({channel.id}) deleted'
+        self.journal.send('channel/delete', channel.guild, content, icon='delete')

--- a/futaba/cogs/misc/__init__.py
+++ b/futaba/cogs/misc/__init__.py
@@ -2,7 +2,7 @@
 # cogs/misc/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/misc/core.py
+++ b/futaba/cogs/misc/core.py
@@ -33,6 +33,7 @@ __all__ = [
 class Miscellaneous:
     __slots__ = (
         'bot',
+        'journal',
     )
 
     def __init__(self, bot):

--- a/futaba/cogs/misc/core.py
+++ b/futaba/cogs/misc/core.py
@@ -2,7 +2,7 @@
 # cogs/misc/core.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/misc/core.py
+++ b/futaba/cogs/misc/core.py
@@ -37,6 +37,7 @@ class Miscellaneous:
 
     def __init__(self, bot):
         self.bot = bot
+        self.journal = bot.get_broadcaster('/misc')
 
     @commands.command(name='ping')
     async def ping(self, ctx):
@@ -59,5 +60,6 @@ class Miscellaneous:
         Shuts down the bot. Only able to be run by an owner.
         '''
 
+        self.journal.send('admin/shutdown', ctx.guild, 'Shutting down bot', icon='shutdown')
         await Reactions.SUCCESS.add(ctx.message)
         exit()

--- a/futaba/cogs/reloader/__init__.py
+++ b/futaba/cogs/reloader/__init__.py
@@ -1,0 +1,21 @@
+#
+# cogs/reloader/__init__.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+from .core import Reloader
+
+def setup(bot):
+    '''
+    Setup for bot to add cog
+    '''
+
+    cog = Reloader(bot)
+    bot.add_cog(cog)

--- a/futaba/cogs/reloader/__init__.py
+++ b/futaba/cogs/reloader/__init__.py
@@ -2,7 +2,7 @@
 # cogs/reloader/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -2,7 +2,7 @@
 # cogs/reloader/core.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -36,6 +36,8 @@ class Reloader:
         'bot',
     )
 
+    MANDATORY_COGS = ('journal', 'reloader')
+
     def __init__(self, bot):
         self.bot = bot
 
@@ -56,22 +58,33 @@ class Reloader:
 
         logger.info("Cog load requested: %s", cogname)
 
+        if cogname in Reloader.MANDATORY_COGS:
+            logger.info("Cog cannot be loaded because it is mandatory")
+            embed = discord.Embed(colour=discord.Colour.red())
+            embed.set_author(name='Cannot load')
+            embed.description = 'Cog cannot be loaded because it is mandatory'
+            await asyncio.gather(
+                ctx.send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+            return
+
         try:
             self.load_cog(cogname)
         except Exception as error:
             logger.error("Loading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
+            embed = discord.Embed(colour=discord.Colour.red(), description=f'```{error}```')
             embed.set_author(name='Load failed')
             await asyncio.gather(
-                self.bot._send(embed=embed),
+                ctx.send(embed=embed),
                 Reactions.FAIL.add(ctx.message),
             )
         else:
             logger.info("Loaded cog: %s", cogname)
-            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
+            embed = discord.Embed(colour=discord.Colour.green(), description=f'```{cogname}```')
             embed.set_author(name='Loaded')
             await asyncio.gather(
-                self.bot._send(embed=embed),
+                ctx.send(embed=embed),
                 Reactions.SUCCESS.add(ctx.message),
             )
 
@@ -82,22 +95,33 @@ class Reloader:
 
         logger.info("Cog unload requested: %s", cogname)
 
+        if cogname in Reloader.MANDATORY_COGS:
+            logger.info("Cog cannot be unloaded because it is mandatory")
+            embed = discord.Embed(colour=discord.Colour.red())
+            embed.set_author(name='Cannot unload')
+            embed.description = 'Cog cannot be unloaded because it is mandatory'
+            await asyncio.gather(
+                ctx.send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+            return
+
         try:
             self.unload_cog(cogname)
         except Exception as error:
             logger.error("Unloading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
+            embed = discord.Embed(colour=discord.Colour.red(), description=f'```{error}```')
             embed.set_author(name='Unload failed')
             await asyncio.gather(
-                self.bot._send(embed=embed),
+                ctx.send(embed=embed),
                 Reactions.FAIL.add(ctx.message),
             )
         else:
             logger.info("Unloaded cog: %s", cogname)
-            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
+            embed = discord.Embed(colour=discord.Colour.green(), description=f'```{cogname}```')
             embed.set_author(name='Unloaded')
             await asyncio.gather(
-                self.bot._send(embed=embed),
+                ctx.send(embed=embed),
                 Reactions.SUCCESS.add(ctx.message),
             )
 
@@ -108,20 +132,31 @@ class Reloader:
 
         logger.info("Cog reload requested: %s", cogname)
 
+        if cogname in Reloader.MANDATORY_COGS:
+            logger.info("Cog cannot be reloaded because it is mandatory")
+            embed = discord.Embed(colour=discord.Colour.red())
+            embed.set_author(name='Cannot reload')
+            embed.description = 'Cog cannot be reloaded because it is mandatory'
+            await asyncio.gather(
+                ctx.send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+            return
+
         try:
             self.unload_cog(cogname)
             self.load_cog(cogname)
         except Exception as error:
             logger.error("Reloading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
+            embed = discord.Embed(colour=discord.Colour.red(), description=f'```{error}```')
             embed.set_author(name='Reload failed')
             await asyncio.gather(
-                self.bot._send(embed=embed),
+                ctx.send(embed=embed),
                 Reactions.FAIL.add(ctx.message),
             )
         else:
             logger.info("Reloaded cog: %s", cogname)
-            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
+            embed = discord.Embed(colour=discord.Colour.green(), description=f'```{cogname}```')
             embed.set_author(name='Reloaded')
             await asyncio.gather(
                 self.bot._send(embed=embed),

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -1,0 +1,146 @@
+#
+# cogs/reloader/core.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Cog for loading, unloading, or reloading other cogs.
+'''
+
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from futaba import permissions
+from futaba.enums import Reactions
+
+COGS_DIR = 'futaba.cogs.'
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'Reloader',
+]
+
+class Reloader:
+    __slots__ = (
+        'bot',
+    )
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    def load_cog(self, cogname):
+        if not cogname.startswith(COGS_DIR):
+            cogname = f'{COGS_DIR}{cogname}'
+        self.bot.load_extension(cogname)
+
+    def unload_cog(self, cogname):
+        if not cogname.startswith(COGS_DIR):
+            cogname = f'{COGS_DIR}{cogname}'
+        self.bot.unload_extension(cogname)
+
+    @commands.command(name='load', aliases=['l'])
+    @permissions.check_owner()
+    async def load(self, ctx, cogname: str):
+        ''' Loads the given cog '''
+
+        logger.info("Cog load requested: %s", cogname)
+
+        try:
+            self.load_cog(cogname)
+        except Exception as error:
+            logger.error("Loading cog %s failed", cogname, exc_info=error)
+            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
+            embed.set_author(name='Load failed')
+            await asyncio.gather(
+                self.bot._send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+        else:
+            logger.info("Loaded cog: %s", cogname)
+            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
+            embed.set_author(name='Loaded')
+            await asyncio.gather(
+                self.bot._send(embed=embed),
+                Reactions.SUCCESS.add(ctx.message),
+            )
+
+    @commands.command(name='unload', aliases=['ul'])
+    @permissions.check_owner()
+    async def unload(self, ctx, cogname: str):
+        ''' Unloads the cog given '''
+
+        logger.info("Cog unload requested: %s", cogname)
+
+        try:
+            self.unload_cog(cogname)
+        except Exception as error:
+            logger.error("Unloading cog %s failed", cogname, exc_info=error)
+            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
+            embed.set_author(name='Unload failed')
+            await asyncio.gather(
+                self.bot._send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+        else:
+            logger.info("Unloaded cog: %s", cogname)
+            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
+            embed.set_author(name='Unloaded')
+            await asyncio.gather(
+                self.bot._send(embed=embed),
+                Reactions.SUCCESS.add(ctx.message),
+            )
+
+    @commands.command(name='reload', aliases=['rl'])
+    @permissions.check_owner()
+    async def reload(self, ctx, cogname: str):
+        ''' Reloads the cog given '''
+
+        logger.info("Cog reload requested: %s", cogname)
+
+        try:
+            self.unload_cog(cogname)
+            self.load_cog(cogname)
+        except Exception as error:
+            logger.error("Reloading cog %s failed", cogname, exc_info=error)
+            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
+            embed.set_author(name='Reload failed')
+            await asyncio.gather(
+                self.bot._send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+        else:
+            logger.info("Reloaded cog: %s", cogname)
+            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
+            embed.set_author(name='Reloaded')
+            await asyncio.gather(
+                self.bot._send(embed=embed),
+                Reactions.SUCCESS.add(ctx.message),
+            )
+
+    @commands.command(name='listcogs', aliases=['cogs'])
+    async def listcogs(self, ctx):
+        '''
+        List the cogs that are currently loaded
+        '''
+
+        lines = ['```yaml', 'Cogs loaded:']
+
+        if self.bot.cogs:
+            for cog in self.bot.cogs:
+                lines.append(f' - {cog}')
+        else:
+            lines.append(' - (none)')
+
+        lines.append('```')
+        await ctx.send('\n'.join(lines))

--- a/futaba/cogs/settings/__init__.py
+++ b/futaba/cogs/settings/__init__.py
@@ -2,7 +2,7 @@
 # cogs/settings/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/settings/__init__.py
+++ b/futaba/cogs/settings/__init__.py
@@ -10,12 +10,12 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-from .core import SettingsCog
+from .core import Settings
 
 def setup(bot):
     '''
     Setup for bot to add cog
     '''
 
-    cog = SettingsCog(bot)
+    cog = Settings(bot)
     bot.add_cog(cog)

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -2,7 +2,7 @@
 # cogs/settings/core.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -26,10 +26,10 @@ from futaba import permissions
 logger = logging.getLogger(__name__)
 
 __all__ = [
-    'SettingsCog',
+    'Settings',
 ]
 
-class SettingsCog:
+class Settings:
     __slots__ = (
         'bot',
     )

--- a/futaba/cogs/tracker/__init__.py
+++ b/futaba/cogs/tracker/__init__.py
@@ -1,5 +1,5 @@
 #
-# cogs/journal/__init__.py
+# cogs/tracking/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
 # Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
@@ -10,12 +10,14 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-from .core import Journal
+from .core import Tracker, LISTENERS
 
 def setup(bot):
     '''
     Setup for bot to add cog
     '''
 
-    cog = Journal(bot)
+    cog = Tracker(bot)
+    for listener in LISTENERS:
+        bot.add_listener(getattr(cog, listener), listener)
     bot.add_cog(cog)

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -104,12 +104,12 @@ class Tracker:
         self.journal.send('jump/message/new', message.guild, message.jump_url, icon='previous')
 
     async def on_message_edit(self, before, after):
-        if message in self.edited_messages:
+        if after in self.edited_messages:
             return
         else:
-            self.edited_messages.append(message)
+            self.edited_messages.append(after)
 
-        if message.guild is None or message.author == self.bot.user:
+        if after.guild is None or after.author == self.bot.user:
             return
 
         logger.debug("Message %d by %s (%d) in #%s (%d) was edited",
@@ -117,7 +117,7 @@ class Tracker:
 
         content = f'{user_discrim(after.author)} edited message {after.id} in {after.channel.mention}'
         self.journal.send('message/edit', after.guild, content, icon='edit')
-        self.journal.send('jump/message/edit', message.guild, message.jump_url, icon='previous')
+        self.journal.send('jump/message/edit', after.guild, after.jump_url, icon='previous')
 
     async def on_message_delete(self, message):
         if message.guild is None:

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -2,7 +2,7 @@
 # config.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/enums.py
+++ b/futaba/enums.py
@@ -2,7 +2,7 @@
 # enums.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/journal/__init__.py
+++ b/futaba/journal/__init__.py
@@ -2,7 +2,7 @@
 # journal/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/journal/__init__.py
+++ b/futaba/journal/__init__.py
@@ -23,6 +23,7 @@ from .router import Router
 
 __all__ = [
     'Broadcaster',
+    'ChannelOutputListener',
     'Listener',
     'Router',
 ]

--- a/futaba/journal/__init__.py
+++ b/futaba/journal/__init__.py
@@ -1,0 +1,36 @@
+#
+# journal/__init__.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Module for defining components of the journaling system.
+This file instantiates a single, global router, and provides
+Broadcaster and Listener classes that rely on it.
+'''
+
+from functools import partial
+
+from .broadcaster import Broadcaster as UnboundBroadcaster
+from .listener import Listener as UnboundListener
+from .router import Router
+
+__all__ = [
+    'JOURNAL',
+    'Broadcaster',
+    'Listener',
+    'Router',
+    'UnboundBroadcaster',
+    'UnboundListener',
+]
+
+JOURNAL = Router()
+Broadcaster = partial(UnboundBroadcaster, JOURNAL)
+Listener = partial(UnboundListener, JOURNAL)

--- a/futaba/journal/__init__.py
+++ b/futaba/journal/__init__.py
@@ -17,7 +17,7 @@ Broadcaster and Listener classes that rely on it.
 '''
 
 from .broadcaster import Broadcaster
-from .listener_impl import ChannelOutputListener
+from .impl import ChannelOutputListener
 from .listener import Listener
 from .router import Router
 

--- a/futaba/journal/__init__.py
+++ b/futaba/journal/__init__.py
@@ -17,13 +17,6 @@ Broadcaster and Listener classes that rely on it.
 '''
 
 from .broadcaster import Broadcaster
-from .impl import ChannelOutputListener
+from .impl import ChannelOutputListener, LoggingOutputListener
 from .listener import Listener
 from .router import Router
-
-__all__ = [
-    'Broadcaster',
-    'ChannelOutputListener',
-    'Listener',
-    'Router',
-]

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -26,14 +26,14 @@ class Broadcaster:
     )
 
     def __init__(self, router, path):
-        assert len(path.parts) > 1, "Cannot broadcast on the root"
         self.router = router
         self.path = PurePath(path)
+        assert len(self.path.parts) > 1, "Cannot broadcast on the root"
 
     def send(self, subpath, guild, content, **attributes):
         # Get full path
         subpath = PurePath(subpath)
-        assert not subpath.is_absolute, "Cannot broadcast on absolute subpath"
+        assert not subpath.is_absolute(), "Cannot broadcast on absolute subpath"
         path = self.path.joinpath(subpath)
 
         # Queue up event

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -29,7 +29,7 @@ class Broadcaster:
         self.router = router
         self.path = PurePath(path)
 
-    def send(self, subpath, content, attributes=None):
+    def send(self, subpath, guild, content, attributes=None):
         # Get full path
         subpath = PurePath(subpath)
         assert not subpath.is_absolute, "Broadcasting on absolute subpath"
@@ -38,4 +38,4 @@ class Broadcaster:
         # Queue up event
         attributes = attributes or {}
         logger.info("Sending journal entry to %s: '%s' %s", path, content, attributes)
-        self.router.queue.put_nowait((path, content, attributes))
+        self.router.queue.put_nowait((path, guild, content, attributes))

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -26,13 +26,14 @@ class Broadcaster:
     )
 
     def __init__(self, router, path):
+        assert len(path.parts) > 1, "Cannot broadcast on the root"
         self.router = router
         self.path = PurePath(path)
 
     def send(self, subpath, guild, content, attributes=None):
         # Get full path
         subpath = PurePath(subpath)
-        assert not subpath.is_absolute, "Broadcasting on absolute subpath"
+        assert not subpath.is_absolute, "Cannot broadcast on absolute subpath"
         path = self.path.joinpath(subpath)
 
         # Queue up event

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -30,13 +30,12 @@ class Broadcaster:
         self.router = router
         self.path = PurePath(path)
 
-    def send(self, subpath, guild, content, attributes=None):
+    def send(self, subpath, guild, content, **attributes):
         # Get full path
         subpath = PurePath(subpath)
         assert not subpath.is_absolute, "Cannot broadcast on absolute subpath"
         path = self.path.joinpath(subpath)
 
         # Queue up event
-        attributes = attributes or {}
         logger.info("Sending journal entry to %s: '%s' %s", path, content, attributes)
         self.router.queue.put_nowait((path, guild, content, attributes))

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -1,0 +1,43 @@
+#
+# journal/broadcaster.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+import logging
+from pathlib import PurePath
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'Broadcaster',
+]
+
+class Broadcaster:
+    __slots__ = (
+        'router',
+        'path',
+    )
+
+    def __init__(self, router, path):
+        self.router = router
+        self.path = PurePath(path)
+
+    def send(self, subpath, content, attributes=None):
+        # Get full path
+        subpath = PurePath(subpath)
+        assert not subpath.is_absolute, "Broadcasting on absolute subpath"
+        path = self.path.joinpath(subpath)
+
+        # Replace attributes if not passed
+        attributes = attributes or {}
+
+        # Queue up event
+        logger.info("Sending journal entry to %s: '%s' %s", path, content, attributes)
+        self.router.queue.put_nowait((path, content, attributes))

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -35,9 +35,7 @@ class Broadcaster:
         assert not subpath.is_absolute, "Broadcasting on absolute subpath"
         path = self.path.joinpath(subpath)
 
-        # Replace attributes if not passed
-        attributes = attributes or {}
-
         # Queue up event
+        attributes = attributes or {}
         logger.info("Sending journal entry to %s: '%s' %s", path, content, attributes)
         self.router.queue.put_nowait((path, content, attributes))

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -2,7 +2,7 @@
 # journal/broadcaster.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/journal/impl/__init__.py
+++ b/futaba/journal/impl/__init__.py
@@ -1,5 +1,5 @@
 #
-# journal/__init__.py
+# journal/impl/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
 # Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
@@ -11,18 +11,11 @@
 #
 
 '''
-Module for defining components of the journaling system.
-This file instantiates a single, global router, and provides
-Broadcaster and Listener classes that rely on it.
+Module for implementations of Listeners or other subclasses.
 '''
 
-from .broadcaster import Broadcaster
-from .listener_impl import ChannelOutputListener
-from .listener import Listener
-from .router import Router
+from .channel_output import ChannelOutputListener
 
 __all__ = [
-    'Broadcaster',
-    'Listener',
-    'Router',
+    'ChannelOutputListener',
 ]

--- a/futaba/journal/impl/__init__.py
+++ b/futaba/journal/impl/__init__.py
@@ -2,7 +2,7 @@
 # journal/impl/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/journal/impl/__init__.py
+++ b/futaba/journal/impl/__init__.py
@@ -15,7 +15,4 @@ Module for implementations of Listeners or other subclasses.
 '''
 
 from .channel_output import ChannelOutputListener
-
-__all__ = [
-    'ChannelOutputListener',
-]
+from .logging_output import LoggingOutputListener

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -39,6 +39,8 @@ ICONS = {
     # Moderation
     'ban': '\N{HAMMER}',
     'kick': '\N{WOMANS BOOTS}',
+    'muffled': '\N{FACE WITH MEDICAL MASK}',
+    'mute': '\N{SPEAK-NO-EVIL MONKEY}',
     'jail': '\N{POLICE CARS REVOLVING LIGHT}',
 
     # Filter
@@ -50,10 +52,15 @@ ICONS = {
     'has-mail': '\N{OPEN MAILBOX WITH RAISED FLAG}',
     'no-mail': '\N{CLOSED MAILBOX WITH LOWERED FLAG}',
 
+    # Watchdog
+    'investigate': '\N{SLEUTH OR SPY}',
+    'watch': '\N{EYE}',
+
     # Configuration
     'edit': '\N{MEMO}',
     'save': '\N{FLOPPY DISK}',
-    'settings': '\N{WRENCH}',
+    'writing': '\N{WRITING HAND}',
+    'settings': '\N{HAMMER AND WRENCH}',
 
     # Development
     'deploy': '\N{ROCKET}',
@@ -71,17 +78,22 @@ ICONS = {
     'book': '\N{NOTEBOOK WITH DECORATIVE COVER}',
     'upload': '\N{OUTBOX TRAY}',
     'download': '\N{INBOX TRAY}',
-    'briefcase': '\N{BRIEFCASE}',
     'bookmark': '\N{BOOKMARK}',
     'journal': '\N{LEDGER}',
     'attachment': '\N{PAPERCLIP}',
     'clipboard': '\N{CLIPBOARD}',
     'pin': '\N{PUSHPIN}',
+    'briefcase': '\N{BRIEFCASE}',
+    'cabinet': '\N{CARD FILE BOX}',
+    'trash': '\N{WASTEBASKET}',
 
     # Miscellaneous
     'hourglass': '\N{HOURGLASS WITH FLOWING SAND}',
     'person': '\N{BUST IN SILHOUETTE}',
+    'navigate': '\N{COMPASS}',
+    'bot': '\N{ROBOT FACE}',
     'news': '\N{NEWSPAPER}',
+    'art': '\N{ARTIST PALETTE}',
     'tag': '\N{TICKET}',
     'music': '\N{MUSICAL NOTE}',
     'link': '\N{LINK SYMBOL}',
@@ -101,7 +113,18 @@ class ChannelOutputListener(Listener):
         super().__init__(router, path, recursive, filter)
         self.channel = channel
 
-    async def handle(self, path, content, attributes):
+    def filter(self, path, guild, content, attributes):
+        '''
+        Ensures that this event is actually meant for this channel output logger.
+        '''
+
+        if self.channel not in guild.channels:
+            logger.debug("Skipping event, wrong guild!")
+            return False
+
+        return True
+
+    async def handle(self, path, guild, content, attributes):
         '''
         Send the message to the given channel, applying the icon if applicable.
         '''

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -21,92 +21,8 @@ from ..listener import Listener
 logger = logging.getLogger(__name__)
 
 __all__ = [
-    'ICONS',
     'ChannelOutputListener',
 ]
-
-ICONS = {
-    # Logging levels
-    'info': '\N{INFORMATION SOURCE}',
-    'idea': '\N{ELECTRIC LIGHT BULB}',
-    'warning': '\N{WARNING SIGN}',
-    'error': '\N{CROSS MARK}',
-    'forbidden': '\N{NO ENTRY}',
-    'critical': '\N{SQUARED SOS}',
-    'ok': '\N{SQUARED OK}',
-    'announce': '\N{CHEERING MEGAPHONE}',
-
-    # Moderation
-    'ban': '\N{HAMMER}',
-    'kick': '\N{WOMANS BOOTS}',
-    'muffled': '\N{FACE WITH MEDICAL MASK}',
-    'mute': '\N{SPEAK-NO-EVIL MONKEY}',
-    'jail': '\N{POLICE CARS REVOLVING LIGHT}',
-
-    # Filter
-    'flag': '\N{TRIANGULAR FLAG ON POST}',
-    'deleted': '\N{SKULL}',
-    'nsfw': '\N{NO ONE UNDER EIGHTEEN SYMBOL}',
-
-    # Mail
-    'has-mail': '\N{OPEN MAILBOX WITH RAISED FLAG}',
-    'no-mail': '\N{CLOSED MAILBOX WITH LOWERED FLAG}',
-
-    # Watchdog
-    'investigate': '\N{SLEUTH OR SPY}',
-    'watch': '\N{EYE}',
-
-    # Configuration
-    'edit': '\N{MEMO}',
-    'save': '\N{FLOPPY DISK}',
-    'writing': '\N{WRITING HAND}',
-    'settings': '\N{HAMMER AND WRENCH}',
-
-    # Development
-    'deploy': '\N{ROCKET}',
-    'package': '\N{PACKAGE}',
-    'script': '\N{SCROLL}',
-
-    # Security
-    'key': '\N{KEY}',
-    'lock': '\N{LOCK}',
-    'unlock': '\N{OPEN LOCK}',
-
-    # Documents
-    'folder': '\N{OPEN FILE FOLDER}',
-    'file': '\N{PAGE FACING UP}',
-    'book': '\N{NOTEBOOK WITH DECORATIVE COVER}',
-    'upload': '\N{OUTBOX TRAY}',
-    'download': '\N{INBOX TRAY}',
-    'bookmark': '\N{BOOKMARK}',
-    'journal': '\N{LEDGER}',
-    'attachment': '\N{PAPERCLIP}',
-    'clipboard': '\N{CLIPBOARD}',
-    'pin': '\N{PUSHPIN}',
-    'briefcase': '\N{BRIEFCASE}',
-    'cabinet': '\N{CARD FILE BOX}',
-    'trash': '\N{WASTEBASKET}',
-
-    # Miscellaneous
-    'hourglass': '\N{HOURGLASS WITH FLOWING SAND}',
-    'person': '\N{BUST IN SILHOUETTE}',
-    'navigate': '\N{COMPASS}',
-    'bot': '\N{ROBOT FACE}',
-    'news': '\N{NEWSPAPER}',
-    'art': '\N{ARTIST PALETTE}',
-    'tag': '\N{TICKET}',
-    'music': '\N{MUSICAL NOTE}',
-    'link': '\N{LINK SYMBOL}',
-    'alert': '\N{BELL}',
-    'game': '\N{VIDEO GAME}',
-    'search': '\N{LEFT-POINTING MAGNIFYING GLASS}',
-    'bomb': '\N{BOMB}',
-    'gift': '\N{WRAPPED PRESENT}',
-    'celebration': '\N{PARTY POPPER}',
-    'international': '\N{GLOBE WITH MERIDIANS}',
-    'award': '\N{TROPHY}',
-    'luck': '\N{FOUR LEAF CLOVER}',
-}
 
 class ChannelOutputListener(Listener):
     def __init__(self, router, path, channel, recursive=True):
@@ -128,10 +44,6 @@ class ChannelOutputListener(Listener):
         '''
         Send the message to the given channel, applying the icon if applicable.
         '''
-
-        icon = attributes.get('icon', None)
-        if icon is not None:
-            content = f'{ICONS[icon]} {content}'
 
         logger.info("Received journal event on %s: '%s'", path, content)
         await self.channel.send(content=content)

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -34,6 +34,10 @@ class ChannelOutputListener(Listener):
         Ensures that this event is actually meant for this channel output logger.
         '''
 
+        if guild is None:
+            logger.debug("Skipping event, no guild attached")
+            return
+
         if self.channel not in guild.channels:
             logger.debug("Skipping event, wrong guild!")
             return False

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -109,8 +109,8 @@ ICONS = {
 }
 
 class ChannelOutputListener(Listener):
-    def __init__(self, router, path, channel, recursive=True, filter=None):
-        super().__init__(router, path, recursive, filter)
+    def __init__(self, router, path, channel, recursive=True):
+        super().__init__(router, path, recursive)
         self.channel = channel
 
     def filter(self, path, guild, content, attributes):

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -34,6 +34,7 @@ ICONS = {
     'forbidden': '\N{NO ENTRY}',
     'critical': '\N{SQUARED SOS}',
     'ok': '\N{SQUARED OK}',
+    'announce': '\N{CHEERING MEGAPHONE}',
 
     # Moderation
     'ban': '\N{HAMMER}',

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -1,0 +1,113 @@
+#
+# journal/impl/channel_output.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+A Listener that outputs messages to the configured Discord channel.
+'''
+
+import logging
+
+from ..listener import Listener
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'ICONS',
+    'ChannelOutputListener',
+]
+
+ICONS = {
+    # Logging levels
+    'info': '\N{INFORMATION SOURCE}',
+    'idea': '\N{ELECTRIC LIGHT BULB}',
+    'warning': '\N{WARNING SIGN}',
+    'error': '\N{CROSS MARK}',
+    'forbidden': '\N{NO ENTRY}',
+    'critical': '\N{SQUARED SOS}',
+    'ok': '\N{SQUARED OK}',
+
+    # Moderation
+    'ban': '\N{HAMMER}',
+    'kick': '\N{WOMANS BOOTS}',
+    'jail': '\N{POLICE CARS REVOLVING LIGHT}',
+
+    # Filter
+    'flag': '\N{TRIANGULAR FLAG ON POST}',
+    'deleted': '\N{SKULL}',
+    'nsfw': '\N{NO ONE UNDER EIGHTEEN SYMBOL}',
+
+    # Mail
+    'has-mail': '\N{OPEN MAILBOX WITH RAISED FLAG}',
+    'no-mail': '\N{CLOSED MAILBOX WITH LOWERED FLAG}',
+
+    # Configuration
+    'edit': '\N{MEMO}',
+    'save': '\N{FLOPPY DISK}',
+    'settings': '\N{WRENCH}',
+
+    # Development
+    'deploy': '\N{ROCKET}',
+    'package': '\N{PACKAGE}',
+    'script': '\N{SCROLL}',
+
+    # Security
+    'key': '\N{KEY}',
+    'lock': '\N{LOCK}',
+    'unlock': '\N{OPEN LOCK}',
+
+    # Documents
+    'folder': '\N{OPEN FILE FOLDER}',
+    'file': '\N{PAGE FACING UP}',
+    'book': '\N{NOTEBOOK WITH DECORATIVE COVER}',
+    'upload': '\N{OUTBOX TRAY}',
+    'download': '\N{INBOX TRAY}',
+    'briefcase': '\N{BRIEFCASE}',
+    'bookmark': '\N{BOOKMARK}',
+    'journal': '\N{LEDGER}',
+    'attachment': '\N{PAPERCLIP}',
+    'clipboard': '\N{CLIPBOARD}',
+    'pin': '\N{PUSHPIN}',
+
+    # Miscellaneous
+    'hourglass': '\N{HOURGLASS WITH FLOWING SAND}',
+    'person': '\N{BUST IN SILHOUETTE}',
+    'news': '\N{NEWSPAPER}',
+    'tag': '\N{TICKET}',
+    'music': '\N{MUSICAL NOTE}',
+    'link': '\N{LINK SYMBOL}',
+    'alert': '\N{BELL}',
+    'game': '\N{VIDEO GAME}',
+    'search': '\N{LEFT-POINTING MAGNIFYING GLASS}',
+    'bomb': '\N{BOMB}',
+    'gift': '\N{WRAPPED PRESENT}',
+    'celebration': '\N{PARTY POPPER}',
+    'international': '\N{GLOBE WITH MERIDIANS}',
+    'award': '\N{TROPHY}',
+    'luck': '\N{FOUR LEAF CLOVER}',
+}
+
+class ChannelOutputListener(Listener):
+    def __init__(self, router, path, channel, recursive=True, filter=None):
+        super().__init__(router, path, recursive, filter)
+        self.channel = channel
+
+    async def handle(self, path, content, attributes):
+        '''
+        Send the message to the given channel, applying the icon if applicable.
+        '''
+
+        icon = attributes.get('icon', None)
+        if icon is not None:
+            content = f'{ICONS[icon]} {content}'
+
+        logger.info("Received journal event on %s: '%s'", path, content)
+        await self.channel.send(content=content)

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -36,7 +36,7 @@ class ChannelOutputListener(Listener):
 
         if guild is None:
             logger.debug("Skipping event, no guild attached")
-            return
+            return False
 
         if self.channel not in guild.channels:
             logger.debug("Skipping event, wrong guild!")

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -2,7 +2,7 @@
 # journal/impl/channel_output.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/journal/impl/logging_output.py
+++ b/futaba/journal/impl/logging_output.py
@@ -1,0 +1,36 @@
+#
+# journal/impl/logging_output.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+A Listener that outputs messages to the special logger "futaba.meta.journal".
+'''
+
+import logging
+
+from ..listener import Listener
+
+logger = logging.getLogger('futaba.meta.journal')
+
+__all__ = [
+    'LoggingOutputListener',
+]
+
+class LoggingOutputListener(Listener):
+    async def handle(self, path, guild, content, attributes):
+        '''
+        Logs the message to the output.
+        '''
+
+        level = attributes.get('level', 'info')
+        assert level in ('error', 'warning', 'info', 'debug')
+        log = getattr(logger, level)
+        log("'%s' (%d) %s: %s", guild.name, guild.id, path, content)

--- a/futaba/journal/listener.py
+++ b/futaba/journal/listener.py
@@ -2,7 +2,7 @@
 # journal/listener.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/journal/listener.py
+++ b/futaba/journal/listener.py
@@ -1,0 +1,48 @@
+#
+# journal/listener.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'Listener',
+]
+
+class Listener:
+    __slots__ = (
+        'router',
+        'path',
+        'handler',
+        'recursive',
+        'filter',
+    )
+
+    def __init__(self, router, path, handler, recursive=True, filter=None):
+        self.router = router
+        self.path = path
+        self.handler = handler
+        self.recursive = recursive
+        self.filter = filter
+
+    def check(self, path, content, attributes):
+        if self.filter is not None:
+            if not self.filter(path, content, attributes):
+                logger.debug("Filter rejected journal entry")
+                return False
+
+        if not self.recursive:
+            if self.path != path:
+                logger.debug("Ignoring non-recursive listener")
+                return False
+
+        return True

--- a/futaba/journal/listener.py
+++ b/futaba/journal/listener.py
@@ -12,6 +12,7 @@
 
 import logging
 from abc import abstractmethod
+from pathlib import PurePath
 
 logger = logging.getLogger(__name__)
 
@@ -20,17 +21,15 @@ __all__ = [
 ]
 
 class Listener:
-    def __init__(self, router, path, recursive=True, filter=None):
+    def __init__(self, router, path, recursive=True):
         self.router = router
-        self.path = path
+        self.path = PurePath(path)
         self.recursive = recursive
-        self.filter = filter
 
-    def check(self, path, content, attributes):
-        if self.filter is not None:
-            if not self.filter(path, content, attributes):
-                logger.debug("Filter rejected journal entry")
-                return False
+    def check(self, path, guild, content, attributes):
+        if not self.filter(path, guild, content, attributes):
+            logger.debug("Filter rejected journal entry")
+            return False
 
         if not self.recursive:
             if self.path != path:
@@ -39,8 +38,15 @@ class Listener:
 
         return True
 
+    def filter(self, path, guild, content, attributes):
+        '''
+        Overridable method for further filtering listener events that are passed through.
+        '''
+
+        return True
+
     @abstractmethod
-    async def handle(self, path, content, attributes):
+    async def handle(self, path, guild, content, attributes):
         '''
         Abstract method for handling the event, in whatever way
         the implementation decides.

--- a/futaba/journal/listener.py
+++ b/futaba/journal/listener.py
@@ -11,6 +11,7 @@
 #
 
 import logging
+from abc import abstractmethod
 
 logger = logging.getLogger(__name__)
 
@@ -19,18 +20,9 @@ __all__ = [
 ]
 
 class Listener:
-    __slots__ = (
-        'router',
-        'path',
-        'handler',
-        'recursive',
-        'filter',
-    )
-
-    def __init__(self, router, path, handler, recursive=True, filter=None):
+    def __init__(self, router, path, recursive=True, filter=None):
         self.router = router
         self.path = path
-        self.handler = handler
         self.recursive = recursive
         self.filter = filter
 
@@ -46,3 +38,12 @@ class Listener:
                 return False
 
         return True
+
+    @abstractmethod
+    async def handle(self, path, content, attributes):
+        '''
+        Abstract method for handling the event, in whatever way
+        the implementation decides.
+        '''
+
+        pass

--- a/futaba/journal/process.py
+++ b/futaba/journal/process.py
@@ -56,6 +56,8 @@ ICONS = {
     'item_remove': '\N{HEAVY MINUS SIGN}',
     'item_clear': '\N{HEAVY MULTIPLICATION X}',
     'channel': '#\N{COMBINING ENCLOSING KEYCAP}',
+    'join': '\N{INBOX TRAY}',
+    'leave': '\N{OUTBOX TRAY}',
 
     # Watchdog
     'investigate': '\N{SLEUTH OR SPY}',
@@ -93,6 +95,8 @@ ICONS = {
     'trash': '\N{WASTEBASKET}',
 
     # Miscellaneous
+    'next': '\N{DOWNWARDS BLACK ARROW}',
+    'previous': '\N{UPWARDS BLACK ARROW}',
     'hourglass': '\N{HOURGLASS WITH FLOWING SAND}',
     'person': '\N{BUST IN SILHOUETTE}',
     'navigate': '\N{COMPASS}',

--- a/futaba/journal/process.py
+++ b/futaba/journal/process.py
@@ -38,7 +38,7 @@ ICONS = {
     'jail': '\N{POLICE CARS REVOLVING LIGHT}',
 
     # Filter
-    'filter': '\N{RECEIPT}',
+    'filter': '\N{PAGE WITH CURL}',
     'flag': '\N{TRIANGULAR FLAG ON POST}',
     'deleted': '\N{SKULL}',
     'nsfw': '\N{NO ONE UNDER EIGHTEEN SYMBOL}',

--- a/futaba/journal/process.py
+++ b/futaba/journal/process.py
@@ -1,0 +1,113 @@
+#
+# journal/process.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Middleware for handling events before they are sent to all the listeners.
+'''
+
+__all__ = [
+    'ICONS',
+    'process_content',
+]
+
+ICONS = {
+    # Logging levels
+    'info': '\N{INFORMATION SOURCE}',
+    'idea': '\N{ELECTRIC LIGHT BULB}',
+    'warning': '\N{WARNING SIGN}',
+    'error': '\N{CROSS MARK}',
+    'forbidden': '\N{NO ENTRY}',
+    'critical': '\N{SQUARED SOS}',
+    'ok': '\N{SQUARED OK}',
+    'announce': '\N{CHEERING MEGAPHONE}',
+
+    # Moderation
+    'ban': '\N{HAMMER}',
+    'kick': '\N{WOMANS BOOTS}',
+    'muffled': '\N{FACE WITH MEDICAL MASK}',
+    'mute': '\N{SPEAK-NO-EVIL MONKEY}',
+    'jail': '\N{POLICE CARS REVOLVING LIGHT}',
+
+    # Filter
+    'flag': '\N{TRIANGULAR FLAG ON POST}',
+    'deleted': '\N{SKULL}',
+    'nsfw': '\N{NO ONE UNDER EIGHTEEN SYMBOL}',
+
+    # Mail
+    'has-mail': '\N{OPEN MAILBOX WITH RAISED FLAG}',
+    'no-mail': '\N{CLOSED MAILBOX WITH LOWERED FLAG}',
+
+    # Watchdog
+    'investigate': '\N{SLEUTH OR SPY}',
+    'watch': '\N{EYE}',
+
+    # Configuration
+    'edit': '\N{MEMO}',
+    'save': '\N{FLOPPY DISK}',
+    'writing': '\N{WRITING HAND}',
+    'settings': '\N{HAMMER AND WRENCH}',
+
+    # Development
+    'deploy': '\N{ROCKET}',
+    'package': '\N{PACKAGE}',
+    'script': '\N{SCROLL}',
+
+    # Security
+    'key': '\N{KEY}',
+    'lock': '\N{LOCK}',
+    'unlock': '\N{OPEN LOCK}',
+
+    # Documents
+    'folder': '\N{OPEN FILE FOLDER}',
+    'file': '\N{PAGE FACING UP}',
+    'book': '\N{NOTEBOOK WITH DECORATIVE COVER}',
+    'upload': '\N{OUTBOX TRAY}',
+    'download': '\N{INBOX TRAY}',
+    'bookmark': '\N{BOOKMARK}',
+    'journal': '\N{LEDGER}',
+    'attachment': '\N{PAPERCLIP}',
+    'clipboard': '\N{CLIPBOARD}',
+    'pin': '\N{PUSHPIN}',
+    'briefcase': '\N{BRIEFCASE}',
+    'cabinet': '\N{CARD FILE BOX}',
+    'trash': '\N{WASTEBASKET}',
+
+    # Miscellaneous
+    'hourglass': '\N{HOURGLASS WITH FLOWING SAND}',
+    'person': '\N{BUST IN SILHOUETTE}',
+    'navigate': '\N{COMPASS}',
+    'bot': '\N{ROBOT FACE}',
+    'news': '\N{NEWSPAPER}',
+    'art': '\N{ARTIST PALETTE}',
+    'tag': '\N{TICKET}',
+    'music': '\N{MUSICAL NOTE}',
+    'link': '\N{LINK SYMBOL}',
+    'alert': '\N{BELL}',
+    'game': '\N{VIDEO GAME}',
+    'search': '\N{LEFT-POINTING MAGNIFYING GLASS}',
+    'bomb': '\N{BOMB}',
+    'gift': '\N{WRAPPED PRESENT}',
+    'celebration': '\N{PARTY POPPER}',
+    'international': '\N{GLOBE WITH MERIDIANS}',
+    'award': '\N{TROPHY}',
+    'luck': '\N{FOUR LEAF CLOVER}',
+}
+
+def process_content(content, attributes):
+    ''' Modifies the content based on the passed attributes. '''
+
+    # Add icon
+    icon = attributes.get('icon', None)
+    if icon is not None:
+        content = f'{ICONS[icon]} {content}'
+
+    return content

--- a/futaba/journal/process.py
+++ b/futaba/journal/process.py
@@ -38,6 +38,7 @@ ICONS = {
     'jail': '\N{POLICE CARS REVOLVING LIGHT}',
 
     # Filter
+    'filter': '\N{RECEIPT}',
     'flag': '\N{TRIANGULAR FLAG ON POST}',
     'deleted': '\N{SKULL}',
     'nsfw': '\N{NO ONE UNDER EIGHTEEN SYMBOL}',
@@ -48,7 +49,7 @@ ICONS = {
 
     # Watchdog
     'investigate': '\N{SLEUTH OR SPY}',
-    'watch': '\N{EYE}',
+    'found': '\N{EYE}',
 
     # Configuration
     'edit': '\N{MEMO}',

--- a/futaba/journal/process.py
+++ b/futaba/journal/process.py
@@ -36,6 +36,7 @@ ICONS = {
     'muffled': '\N{FACE WITH MEDICAL MASK}',
     'mute': '\N{SPEAK-NO-EVIL MONKEY}',
     'jail': '\N{POLICE CARS REVOLVING LIGHT}',
+    'shutdown': '\N{SKULL}',
 
     # Filter
     'filter': '\N{PAGE WITH CURL}',

--- a/futaba/journal/process.py
+++ b/futaba/journal/process.py
@@ -48,6 +48,15 @@ ICONS = {
     'has-mail': '\N{OPEN MAILBOX WITH RAISED FLAG}',
     'no-mail': '\N{CLOSED MAILBOX WITH LOWERED FLAG}',
 
+    # Tracking
+    'typing': '\N{WRITING HAND}',
+    'message': '\N{PAGE FACING UP}',
+    'delete': '\N{WASTEBASKET}',
+    'item_add': '\N{HEAVY PLUS SIGN}',
+    'item_remove': '\N{HEAVY MINUS SIGN}',
+    'item_clear': '\N{HEAVY MULTIPLICATION X}',
+    'channel': '#\N{COMBINING ENCLOSING KEYCAP}',
+
     # Watchdog
     'investigate': '\N{SLEUTH OR SPY}',
     'found': '\N{EYE}',

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -2,7 +2,7 @@
 # journal/router.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -55,7 +55,7 @@ class Router:
             for path in chain((event_path,), event_path.parents):
                 for listener in self.paths[path]:
                     if listener.check(path, guild, content, attributes):
-                        events.append(listener.handle(path, guild, content, attributes))
+                        events.append(listener.handle(event_path, guild, content, attributes))
 
             # Run all the event handlers
             await asyncio.gather(*events)

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -1,0 +1,54 @@
+#
+# journal/router.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+import asyncio
+import logging
+from collections import defaultdict
+from itertools import chain
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'Router',
+]
+
+class Router:
+    __slots__ = (
+        'paths',
+        'queue',
+    )
+
+    def __init__(self):
+        self.paths = defaultdict(list)
+        self.queue = asyncio.Queue()
+
+    def start(self, eventloop):
+        logger.info("Start journal event processing task")
+        eventloop.create_task(self.process_events())
+
+    async def process_events(self):
+        events = []
+
+        while True:
+            logger.debug("Waiting for new journal event")
+            event_path, content, attributes = await self.queue.get()
+            logger.info("Got journal event on %s: '%s' %s", event_path, content, attributes)
+
+            # Add events for this path
+            for path in chain((event_path,), event_path.parents):
+                for listener in self.paths[path]:
+                    if listener.check(path, content, attributes):
+                        events.append(listener.handler(path, content, attributes))
+
+            # Run all the handlers
+            await asyncio.gather(*events)
+            events.clear()

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -35,6 +35,10 @@ class Router:
         logger.info("Start journal event processing task")
         eventloop.create_task(self.process_events())
 
+    def register(self, listener):
+        logger.info("Registering %r on '%s'", listener, listener.path)
+        self.paths[listener.path].append(listener)
+
     async def process_events(self):
         events = []
 

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -47,8 +47,8 @@ class Router:
             for path in chain((event_path,), event_path.parents):
                 for listener in self.paths[path]:
                     if listener.check(path, content, attributes):
-                        events.append(listener.handler(path, content, attributes))
+                        events.append(listener.handle(path, content, attributes))
 
-            # Run all the handlers
+            # Run all the event handlers
             await asyncio.gather(*events)
             events.clear()

--- a/futaba/parse.py
+++ b/futaba/parse.py
@@ -2,7 +2,7 @@
 # discord.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/permissions.py
+++ b/futaba/permissions.py
@@ -2,7 +2,7 @@
 # permissions.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/__init__.py
+++ b/futaba/sql/__init__.py
@@ -2,7 +2,7 @@
 # sql/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/handle.py
+++ b/futaba/sql/handle.py
@@ -18,7 +18,7 @@ import logging
 
 from sqlalchemy import create_engine, MetaData
 
-from .models import FilterModel, GuildsModel, SettingsModel
+from .models import FilterModel, GuildsModel, JournalModel, SettingsModel
 from .transaction import Transaction
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,7 @@ class SqlHandler:
 
         'filter',
         'guilds',
+        'journal',
         'settings',
     )
 
@@ -47,6 +48,7 @@ class SqlHandler:
 
         self.filter = FilterModel(self, meta)
         self.guilds = GuildsModel(self, meta)
+        self.journal = JournalModel(self, meta)
         self.settings = SettingsModel(self, meta)
 
         meta.create_all(self.db)

--- a/futaba/sql/handle.py
+++ b/futaba/sql/handle.py
@@ -2,7 +2,7 @@
 # sql/handle.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/hooks.py
+++ b/futaba/sql/hooks.py
@@ -2,7 +2,7 @@
 # sql/hooks.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/models/__init__.py
+++ b/futaba/sql/models/__init__.py
@@ -20,10 +20,12 @@ import sys
 
 from .filter import FilterModel
 from .guilds import GuildsModel
+from .journal import JournalModel
 from .settings import SettingsModel
 
 __all__ = [
     'FilterModel',
     'GuildsModel',
+    'JournalModel',
     'SettingsModel',
 ]

--- a/futaba/sql/models/__init__.py
+++ b/futaba/sql/models/__init__.py
@@ -2,7 +2,7 @@
 # sql/models/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/models/_skeleton.py
+++ b/futaba/sql/models/_skeleton.py
@@ -2,7 +2,7 @@
 # sql/models/_FILENAME_HERE_.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/models/_skeleton.py
+++ b/futaba/sql/models/_skeleton.py
@@ -1,5 +1,5 @@
 #
-# sql/_FILENAME_HERE_.py
+# sql/models/_FILENAME_HERE_.py
 #
 # futaba - A Discord Mod bot for the Programming server
 # Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
@@ -30,3 +30,10 @@ from sqlalchemy.sql import select
 
 Column = functools.partial(Column, nullable=False)
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    '_SKELETON_Model',
+]
+
+class _SKELETON_Model:
+    pass

--- a/futaba/sql/models/filter.py
+++ b/futaba/sql/models/filter.py
@@ -94,7 +94,8 @@ class FilterModel:
         try:
             self.sql.execute(ins)
             self.filter_cache[location][text] = filter_type
-        except IntegrityError:
+        except IntegrityError as error:
+            logger.error("Unable to insert new filter", exc_info=error)
             raise ValueError("This filter already exists")
 
     def update_filter(self, location, filter_type, text):
@@ -127,7 +128,7 @@ class FilterModel:
                 ))
         result = self.sql.execute(delet)
         self.filter_cache[location].pop(text, None)
-        assert result.rowcount in (0, 1), "Only one matching filter"
+        assert result.rowcount in (0, 1), "Multiple rows deleted"
         return bool(result.rowcount)
 
     def get_filter_immune_users(self, guild):

--- a/futaba/sql/models/filter.py
+++ b/futaba/sql/models/filter.py
@@ -2,7 +2,7 @@
 # sql/filter.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/models/filter.py
+++ b/futaba/sql/models/filter.py
@@ -137,7 +137,7 @@ class FilterModel:
         sel = select([self.tb_filter_immune_users.c.user_id]) \
                 .where(self.tb_filter_immune_users.c.guild_id == guild.id)
         result = self.sql.execute(sel)
-        self.immune_users_cache[guild].update(user_id for user_id, in result.fetchmany())
+        self.immune_users_cache[guild].update(user_id for user_id, in result.fetchall())
         return self.immune_users_cache[guild]
 
     def user_is_filter_immune(self, guild, user):

--- a/futaba/sql/models/guilds.py
+++ b/futaba/sql/models/guilds.py
@@ -2,7 +2,7 @@
 # sql/models/guilds.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/models/guilds.py
+++ b/futaba/sql/models/guilds.py
@@ -72,7 +72,7 @@ class GuildsModel:
         sel = select([self.tb_guilds.c.guild_id])
         result = self.sql.execute(sel)
 
-        return (guild_id for guild_id, in result.fetchmany())
+        return (guild_id for guild_id, in result.fetchall())
 
     @staticmethod
     def _get_guild(bot, guild_id):

--- a/futaba/sql/models/journal.py
+++ b/futaba/sql/models/journal.py
@@ -2,7 +2,7 @@
 # sql/models/journal.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/models/journal.py
+++ b/futaba/sql/models/journal.py
@@ -1,0 +1,163 @@
+#
+# sql/models/journal.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Stores configured information about where journal information should
+be logged into Discord text channels within guilds.
+'''
+
+# False positive when using SQLAlchemy decorators
+# pylint: disable=no-value-for-parameter
+
+import functools
+import logging
+from collections import defaultdict, namedtuple
+
+from sqlalchemy import and_, or_
+from sqlalchemy import BigInteger, Boolean, Column, Table, Text
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql import select
+
+from ..hooks import on_guild_leave
+
+Column = functools.partial(Column, nullable=False)
+ChannelSettings = namedtuple('ChannelSettings', ('recursive'))
+ConfiguredChannelOutput = namedtuple('ConfiguredChannelOutput', ('channel', 'path', 'settings'))
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'ChannelSettings',
+    'ConfiguredChannelOutput',
+    'JournalModel',
+]
+
+class JournalModel:
+    __slots__ = (
+        'sql',
+        'tb_journal_output',
+        'journal_output_cache',
+        'journal_guild_cache',
+    )
+
+    def __init__(self, sql, meta):
+        self.sql = sql
+        self.tb_journal_output = Table('journal_output', meta,
+                Column('guild_id', BigInteger, ForeignKey('guilds.guild_id')),
+                Column('channel_id', BigInteger, primary_key=True),
+                Column('path', Text, primary_key=True),
+                Column('recursive', Boolean),
+                UniqueConstraint('guild_id', 'channel_id', 'path', name='journal_output_uq'))
+        self.journal_output_cache = defaultdict(dict)
+        self.journal_guild_cache = set()
+
+    def add_journal_channel(self, channel, path, recursive):
+        logger.info("Adding journal channel for #%s (%d) on path %s",
+                channel.name, channel.id, path)
+        logger.debug("Settings: recursive = %r", recursive)
+
+        assert channel.guild is not None, "Channel must a guild channel"
+        ins = self.tb_journal_output \
+                    .insert() \
+                    .values(
+                        guild_id=channel.guild.id,
+                        channel_id=channel.id,
+                        path=path,
+                        recursive=recursive,
+                    )
+
+        try:
+            self.sql.execute(ins)
+            self.journal_output_cache[channel][path] = ChannelSettings(recursive=recursive)
+        except IntegrityError as error:
+            logger.error("Unable to insert new journal channel", exc_info=error)
+            raise ValueError("This channel already tracks the given path")
+
+    def update_journal_channel(self, channel, path, recursive):
+        logger.info("Updating journal channel for #%s (%d) on path %s",
+                channel.name, channel.id, path)
+        logger.debug("Settings: recursive = %r", recursive)
+
+        assert channel.guild is not None, "Channel must a guild channel"
+        upd = self.tb_journal_output \
+                    .update() \
+                    .values(recursive=recursive) \
+                    .where(and_(
+                        self.tb_journal_output.c.guild_id == channel.guild.id,
+                        self.tb_journal_output.c.channel_id == channel.id,
+                        self.tb_journal_output.c.path == path,
+                    ))
+
+        self.sql.execute(upd)
+        settings = self.journal_output_cache[channel][path]
+        settings.recursive = recursive
+
+    def delete_journal_channel(self, channel, path):
+        logger.info("Deleting journal channel for #%s (%d) on path '%s'",
+                channel.name, channel.id, path)
+
+        assert channel.guild is not None, "Channel must be a guild channel"
+        delet = self.tb_journal_output \
+                    .delete() \
+                    .where(and_(
+                        self.tb_journal_output.c.guild_id == channel.guild.id,
+                        self.tb_journal_output.c.channel_id == channel.id,
+                        self.tb_journal_output.c.path == path,
+                    ))
+
+        result = self.sql.execute(delet)
+        self.journal_output_cache[channel].pop(path, None)
+        assert result.rowcount in (0, 1), "Multiple rows deleted"
+        return bool(result.rowcount)
+
+    def has_journal_channel(self, channel, path):
+        logger.info("Checking for journal channel on #%s (%d) for path '%s'",
+                channel.name, channel.id, path)
+        return path in self.journal_output_cache[channel]
+
+    def get_journal_channels(self, guild):
+        logger.info("Fetching all journal channel outputs for guild '%s' (%d)",
+                guild.name, guild.id)
+
+        if guild not in self.journal_guild_cache:
+            logger.debug("Guild not in cache list, fetching from database")
+
+            # Perform SELECT
+            logger.debug("Guild not loaded from disk, doing select")
+            sel = select([
+                        self.tb_journal_output.c.channel_id,
+                        self.tb_journal_output.c.path,
+                        self.tb_journal_output.c.recursive,
+                    ]) \
+                    .where(self.tb_journal_output.c.guild_id == guild.id)
+            result = self.sql.execute(sel)
+
+            # Update cache
+            for channel_id, path, recursive in result.fetchmany():
+                channel = guild.get_channel(channel_id)
+                self.journal_output_cache[channel][path] = ChannelSettings(recursive=recursive)
+
+        # Compile guild list
+        outputs = []
+        for channel in guild.channels:
+            for path, settings in self.journal_output_cache[channel].items():
+                outputs.append(ConfiguredChannelOutput(channel=channel, path=path, settings=settings))
+        return outputs
+
+    @on_guild_leave
+    def delete_journal_channels(self, guild):
+        logger.info("Removing all journal channel outputs for guild '%s' (%d)",
+                guild.name, guild.id)
+        delet = self.tb_journal_output \
+                    .delete() \
+                    .where(self.tb_journal_output.c.guild_id == guild.id)
+        result = self.sql.execute(delet)

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -2,7 +2,7 @@
 # sql/models/settings.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/sql/transaction.py
+++ b/futaba/sql/transaction.py
@@ -2,7 +2,7 @@
 # sql/transaction.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/futaba/utils.py
+++ b/futaba/utils.py
@@ -24,12 +24,9 @@ from futaba.enums import Reactions
 
 logger = logging.getLogger(__name__)
 
-COGS_DIR = 'futaba.cogs.'
-
 __all__ = [
     'READABLE_CHAR_SET',
     'Dummy',
-    'Reloader',
     'normalize_caseless',
     'fancy_timedelta',
     'async_partial',
@@ -46,122 +43,6 @@ class Dummy:
     '''
 
     pass
-
-class Reloader:
-    '''
-    Special cog that is used to load, unload, and reload all other cogs.
-    '''
-
-    def __init__(self, bot):
-        self.bot = bot
-
-    def load_cog(self, cogname):
-        if not cogname.startswith(COGS_DIR):
-            cogname = f'{COGS_DIR}{cogname}'
-        self.bot.load_extension(cogname)
-
-    def unload_cog(self, cogname):
-        if not cogname.startswith(COGS_DIR):
-            cogname = f'{COGS_DIR}{cogname}'
-        self.bot.unload_extension(cogname)
-
-    @commands.command()
-    @permissions.check_owner()
-    async def load(self, ctx, cogname: str):
-        ''' Loads the given cog '''
-
-        logger.info("Cog load requested: %s", cogname)
-
-        try:
-            self.load_cog(cogname)
-        except Exception as error:
-            logger.error("Loading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
-            embed.set_author(name='Load failed')
-            await asyncio.gather(
-                self.bot._send(embed=embed),
-                Reactions.FAIL.add(ctx.message),
-            )
-
-        else:
-            logger.info("Loaded cog: %s", cogname)
-            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
-            embed.set_author(name='Loaded')
-            await asyncio.gather(
-                self.bot._send(embed=embed),
-                Reactions.SUCCESS.add(ctx.message),
-            )
-
-    @commands.command()
-    @permissions.check_owner()
-    async def unload(self, ctx, cogname: str):
-        ''' Unloads the cog given '''
-
-        logger.info("Cog unload requested: %s", cogname)
-
-        try:
-            self.unload_cog(cogname)
-        except Exception as error:
-            logger.error("Unloading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
-            embed.set_author(name='Unload failed')
-            await asyncio.gather(
-                self.bot._send(embed=embed),
-                Reactions.FAIL.add(ctx.message),
-            )
-        else:
-            logger.info("Unloaded cog: %s", cogname)
-            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
-            embed.set_author(name='Unloaded')
-            await asyncio.gather(
-                self.bot._send(embed=embed),
-                Reactions.SUCCESS.add(ctx.message),
-            )
-
-    @commands.command()
-    @permissions.check_owner()
-    async def reload(self, ctx, cogname: str):
-        ''' Reloads the cog given '''
-
-        logger.info("Cog reload requested: %s", cogname)
-
-        # Load cog
-        try:
-            self.unload_cog(cogname)
-            self.load_cog(cogname)
-        except Exception as error:
-            logger.error("Reloading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(color=discord.Color.red(), description=f'```{error}```')
-            embed.set_author(name='Reload failed')
-            await asyncio.gather(
-                self.bot._send(embed=embed),
-                Reactions.FAIL.add(ctx.message),
-            )
-        else:
-            logger.info("Reloaded cog: %s", cogname)
-            embed = discord.Embed(color=discord.Color.green(), description=f'```{cogname}```')
-            embed.set_author(name='Reloaded')
-            await asyncio.gather(
-                self.bot._send(embed=embed),
-                Reactions.SUCCESS.add(ctx.message),
-            )
-
-    @commands.command()
-    async def listcogs(self, ctx):
-        '''
-        List the cogs that are currently loaded
-        '''
-
-        lines = ['```yaml', 'Cogs loaded:']
-
-        if self.bot.cogs:
-            for cog in self.bot.cogs:
-                lines.append(f' - {cog}')
-        else:
-            lines.append(' - (none)')
-
-        lines.append('```')
-        await ctx.send('\n'.join(lines))
 
 def normalize_caseless(s):
     '''

--- a/futaba/utils.py
+++ b/futaba/utils.py
@@ -31,6 +31,7 @@ __all__ = [
     'fancy_timedelta',
     'async_partial',
     'plural',
+    'escape_backticks',
     'if_not_null',
     'unicode_repr',
 ]
@@ -86,25 +87,27 @@ def fancy_timedelta(delta):
     return f'{", ".join(parts)} and {seconds} second{plural(seconds)}'
 
 def async_partial(coro, *added_args, **added_kwargs):
-    '''
-    Like functools.partial(), but for coroutines.
-    '''
+    ''' Like functools.partial(), but for coroutines. '''
 
     async def wrapped(*args, **kwargs):
         return await coro(*added_args, *args, **added_kwargs, **kwargs)
     return wrapped
 
 def plural(num):
-    '''
-    Gets the English plural ending for an ordinal number.
-    '''
+    ''' Gets the English plural ending for an ordinal number. '''
 
     return '' if num == 1 else 's'
 
+def escape_backticks(content):
+    '''
+    Replace any backticks in 'content' with a unicode lookalike to allow
+    quoting in Discord.
+    '''
+
+    return content.replace('`', '\N{ARMENIAN COMMA}')
+
 def if_not_null(obj, alt):
-    '''
-    Returns 'obj' if it's not None, 'alt' otherwise.
-    '''
+    ''' Returns 'obj' if it's not None, 'alt' otherwise. '''
 
     if obj is None:
         if callable(alt):

--- a/futaba/utils.py
+++ b/futaba/utils.py
@@ -2,7 +2,7 @@
 # utils.py
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those

--- a/misc/header.txt
+++ b/misc/header.txt
@@ -2,7 +2,7 @@
 # (FILENAME)
 #
 # futaba - A Discord Mod bot for the Programming server
-# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
 #
 # futaba is available free of charge under the terms of the MIT
 # License. You are free to redistribute and/or modify it under those


### PR DESCRIPTION
Add a mandatory journal cog, which has commands for manipulating channel listeners.
Add a Router which can abstractly process journal events and pass them to all relevant listeners.
Make it easy to open a journal broadcaster and start sending events. Non-blocking, it pushes the event to an asynchronous queue to be handled by a looping coroutine.
Move Reloader to its own cog and also make mandatory.
Many other miscellaneous improvements.