### PR TITLE
Add role information commands

### DIFF
--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -243,6 +243,50 @@ class Info:
             Reactions.SUCCESS.add(ctx.message),
         )
 
+    @commands.command(name='roles', aliases=['lroles', 'listroles'])
+    @commands.guild_only()
+    async def roles(self, ctx):
+        ''' Lists all roles in the guild. '''
+
+        contents = []
+        lines = []
+        current_len = 0
+
+        logger.info("Listing roles within the guild")
+        for role in ctx.guild.roles:
+            line = f'- {role.mention} id: `{role.id}`, members: `{len(role.members)}`'
+            current_len += len(line)
+
+            if current_len > 1900:
+                # Too long, break into new embed
+                contents.append('\n'.join(lines))
+
+                # Start lines over
+                lines.clear()
+                lines.append(line)
+                current_len = len(line)
+            else:
+                lines.append(line)
+
+        contents.append('\n'.join(lines))
+        lines.clear()
+
+        async def post_all():
+            for i, content in enumerate(contents):
+                embed = discord.Embed(description=content)
+                page = f'Page {i + 1}/{len(contents)}'
+                if i == 0:
+                    embed.set_author(name=page)
+                else:
+                    embed.set_author(name=f'{page} Roles in {ctx.guild.name}')
+
+                await ctx.send(embed=embed)
+
+        await asyncio.gather(
+            post_all(),
+            Reactions.SUCCESS.add(ctx.message),
+        )
+
     @staticmethod
     async def get_messages(channels, ids):
         return await asyncio.gather(*[Info.get_message(channels, id) for id in ids])

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -23,7 +23,7 @@ import discord
 from discord.ext import commands
 
 from futaba.enums import Reactions
-from futaba.parse import get_user_id, similar_user_ids
+from futaba.parse import get_role_id, get_user_id, similar_user_ids
 from futaba.permissions import check_mod_perm
 from futaba.utils import escape_backticks, fancy_timedelta, first, plural
 
@@ -192,14 +192,24 @@ class Info:
 
     @commands.command(name='rinfo', aliases=['roleinfo', 'role'])
     @commands.guild_only()
-    async def rinfo(self, ctx, *, role: discord.Role = None):
+    async def rinfo(self, ctx, *, name: str = None):
         '''
         Fetches and prints information about a particular role in the current guild.
         If no role is specified, it displays information about the default role.
         '''
 
-        if role is None:
+        if name in (None, '@everyone', 'everyone', '@here', 'here', 'default'):
             role = ctx.guild.default_role
+        else:
+            id = get_role_id(name, ctx.guild.roles)
+            if id is None:
+                role = None
+            else:
+                role = discord.utils.get(ctx.guild.roles, id=id)
+
+        if role is None:
+            await Reactions.FAIL.add(ctx.message)
+            return
 
         logger.info("Running rinfo on '%s'", role)
 

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -78,7 +78,7 @@ class Tracker:
         else:
             self.typing.append((channel, user, when))
 
-        if channel.guild is None:
+        if getattr(channel, 'guild', None) is None:
             return
 
         logger.debug("Received typing event from %s (%d) in #%s (%d)",

--- a/futaba/utils.py
+++ b/futaba/utils.py
@@ -31,6 +31,7 @@ __all__ = [
     'fancy_timedelta',
     'async_partial',
     'first',
+    'lowerbool',
     'plural',
     'escape_backticks',
     'if_not_null',
@@ -109,6 +110,11 @@ def first(iterable, default=None):
         if item:
             return item
     return default
+
+def lowerbool(value):
+    ''' Returns 'true' if the expression is true, and 'false' if not. '''
+
+    return 'true' if value else 'false'
 
 def plural(num):
     ''' Gets the English plural ending for an ordinal number. '''


### PR DESCRIPTION
Fixes #39 

Adds `!rinfo` (similar to `!uinfo`) and `!roles` to list all roles in a guild.