### PR TITLE
Moderation cog

### DIFF
--- a/futaba/cogs/moderation/__init__.py
+++ b/futaba/cogs/moderation/__init__.py
@@ -1,0 +1,21 @@
+#
+# cogs/moderation/__init__.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+from .core import Moderation
+
+def setup(bot):
+    '''
+    Setup for bot to add cog
+    '''
+
+    cog = Moderation(bot)
+    bot.add_cog(cog)

--- a/futaba/cogs/moderation/__init__.py
+++ b/futaba/cogs/moderation/__init__.py
@@ -18,4 +18,6 @@ def setup(bot):
     '''
 
     cog = Moderation(bot)
+    bot.add_listener(cog.member_ban, "on_member_ban")
+    bot.add_listener(cog.member_kick, "on_member_remove")
     bot.add_cog(cog)

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -1,0 +1,93 @@
+#
+# cogs/moderation/core.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+# pylint: skip-file
+
+'''
+Collection of moderation commands such as Ban/Kick
+'''
+
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from futaba import permissions
+from futaba.enums import Reactions
+
+logger = logging.getLogger(__package__)
+
+class Moderation:
+    '''
+    Staff moderation commands
+    '''
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def kick(self, ctx, member: discord.Member, *, reason: str):
+        '''
+        Kicks the user from the guild with a reason
+        If guild has moderation logging enabled, it is logged
+        '''
+
+        try:
+            embed = discord.Embed(description='Done! User Kicked')
+            embed.add_field(name='Reason:', value=reason)
+            
+            await asyncio.gather(
+                ctx.guild.kick(member, reason=reason),
+                Reactions.SUCCESS.add(ctx.message),
+                ctx.send(embed=embed)
+            )
+
+            #TODO Send log about the kick using built-in util 
+        
+        except discord.errors.Forbidden:
+            
+            await asyncio.gather(
+                Reactions.DENY.add(ctx.message),
+                ctx.send("Can't do that user has higher role than me")
+            )
+    
+    @commands.command()
+    @commands.guild_only()
+    @permissions.check_admin()
+    async def ban(self, ctx, member: discord.Member, *, reason: str):
+        '''
+        Bans the user from the guild with a reason
+        If guild has moderation logging enabled, it is logged
+        '''
+
+        try:
+            embed = discord.Embed(description='Done! User Banned')
+            embed.add_field(name='Reason:', value=reason)
+            
+            await asyncio.gather(
+                ctx.guild.ban(member, reason=reason),
+                Reactions.SUCCESS.add(ctx.message),
+                ctx.send(embed=embed)
+            )
+
+            #TODO Send log about the kick using built-in util 
+        
+        except discord.errors.Forbidden:
+            
+            await asyncio.gather(
+                Reactions.DENY.add(ctx.message),
+                ctx.send("Can't do that user has higher role than me")
+            )
+

--- a/futaba/journal/process.py
+++ b/futaba/journal/process.py
@@ -32,6 +32,8 @@ ICONS = {
 
     # Moderation
     'ban': '\N{HAMMER}',
+    'unban': '\N{FACE WITH HEAD-BANDAGE}',
+    'soft': '\N{BED}',
     'kick': '\N{WOMANS BOOTS}',
     'muffled': '\N{FACE WITH MEDICAL MASK}',
     'mute': '\N{SPEAK-NO-EVIL MONKEY}',


### PR DESCRIPTION
Added basic moderation commands.
- Ban
- Kick
- Softban (soft, sban)
- Unban

Each will log to the `/moderation` journal under `member/<command>`. Manual kicks and bans are also logged under this. 
**NOTE:** Currently the manual kick event can fire twice for a user if the user is kicked, rejoins and is banned before someone else is kicked. This is because the kick event is check on user leave and will only look at the kick events therefore if the user is banned that event will assume they are kicked as they have left and have a entry for being kicked. It will also fire if they rejoin and leave after a kick