### PR TITLE
Add command to get and set the prefix

### DIFF
--- a/futaba/__init__.py
+++ b/futaba/__init__.py
@@ -14,20 +14,4 @@
 futaba - A Discord Mod bot for the Programming server
 '''
 
-from . import client, config, download, enums, journal, parse, permissions, str_builder, unicode, utils
-
-__all__ = [
-    '__version__',
-    'client',
-    'config',
-    'download',
-    'enums',
-    'journal',
-    'parse',
-    'permissions',
-    'str_builder',
-    'unicode',
-    'utils',
-]
-
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/futaba/__main__.py
+++ b/futaba/__main__.py
@@ -72,9 +72,13 @@ if __name__ == '__main__':
         discord_logger.addHandler(log_hndl)
 
     if args.stdout:
+        full_logger = logging.getLogger(__package__)
+        full_logger.setLevel(level=logging.DEBUG)
+        full_logger.addHandler(log_hndl)
+
         log_hndl = logging.StreamHandler(sys.stdout)
         log_hndl.setFormatter(log_fmtr)
-        logger.addHandler(log_hndl)
+        full_logger.addHandler(log_hndl)
         if args.discord_log:
             discord_logger.addHandler(log_hndl)
 

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -26,6 +26,7 @@ from .cogs.journal import Journal
 from .cogs.reloader import Reloader
 from .config import Configuration
 from .enums import Reactions
+from .exceptions import InvalidCommandContext
 from .journal import Broadcaster, LoggingOutputListener
 from .sql import SqlHandler
 from .utils import plural
@@ -173,7 +174,7 @@ class Bot(commands.AutoShardedBot):
 
     async def on_command_error(self, ctx, error):
         '''
-        Deals with errors when a command is invoked.
+        Handles errors when a command is invoked but raises an exception.
         '''
 
         # Complains about "context" vs "ctx".
@@ -188,6 +189,11 @@ class Bot(commands.AutoShardedBot):
         elif isinstance(error, commands.errors.CheckFailure):
             # Tell the user they don't have the permission to tun the command
             await Reactions.DENY.add(ctx.message)
+
+        elif isinstance(error, InvalidCommandContext):
+            # Explicitly ignore, this command was not even meant to be invoked in the first place
+            # This is sent when we explicitly DO NOT want to add a SUCCESS reaction.
+            pass
 
     async def _send(self, *args, **kwargs):
         if self.debug_chan is not None:

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -48,19 +48,22 @@ class Bot(commands.AutoShardedBot):
         self.journal_cog = None
         self.debug_chan = None
         self.sql = SqlHandler(config.database_url)
-        super().__init__(command_prefix=self.get_prefix_sql,
+
+        super().__init__(command_prefix=self.command_prefix,
                          description='futaba - A discord mod bot',
                          pm_help=True)
 
     @staticmethod
-    def get_prefix_sql(bot, message):
-        prefix = None
-
-        if message.guild is not None:
-            prefix = bot.sql.settings.get_prefix(message.guild)
-
-        prefix = prefix or bot.config.default_prefix
+    def command_prefix(bot, message):
+        prefix = bot.prefix(message)
         return commands.when_mentioned_or(prefix)(bot, message)
+
+    def prefix(self, message):
+        if message.guild is None:
+            return ''
+
+        prefix = self.sql.settings.get_prefix(message.guild)
+        return prefix or self.config.default_prefix
 
     @property
     def uptime(self):

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -206,6 +206,7 @@ class Bot(commands.AutoShardedBot):
             # TODO send help message for error.command
             pass
 
+    # Remove this?
     async def _send(self, *args, **kwargs):
         if self.debug_chan is not None:
             await self.debug_chan.send(*args, **kwargs)

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -26,7 +26,7 @@ from .cogs.journal import Journal
 from .cogs.reloader import Reloader
 from .config import Configuration
 from .enums import Reactions
-from .exceptions import InvalidCommandContext
+from .exceptions import CommandFailed, InvalidCommandContext, SendHelp
 from .journal import Broadcaster, LoggingOutputListener
 from .sql import SqlHandler
 from .utils import plural
@@ -190,9 +190,20 @@ class Bot(commands.AutoShardedBot):
             # Tell the user they don't have the permission to tun the command
             await Reactions.DENY.add(ctx.message)
 
+        elif isinstance(error, CommandFailed):
+            # The command failed, report the error message (if any) and send the FAIL reaction
+            if error.kwargs:
+                await ctx.send(**error.kwargs)
+
+            await Reactions.FAIL.add(ctx.message)
+
         elif isinstance(error, InvalidCommandContext):
             # Explicitly ignore, this command was not even meant to be invoked in the first place
-            # This is sent when we explicitly DO NOT want to add a SUCCESS reaction.
+            # This is sent when we explicitly DO NOT want to add a SUCCESS reaction
+            pass
+
+        elif isinstance(error, SendHelp):
+            # TODO send help message for error.command
             pass
 
     async def _send(self, *args, **kwargs):

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -121,7 +121,7 @@ class Bot(commands.AutoShardedBot):
             except Exception as error:
                 # Something made the loading fail
                 # So log it with reason and tell user to check it
-                logger.debug("Load failed: %s", file, exc_info=error)
+                logger.error("Load failed: %s", file, exc_info=error)
                 continue
             else:
                 logger.info("Loaded cog: %s", file)

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -125,6 +125,8 @@ class Filtering:
         '''
 
         await check_hashsums((hashsum,), ctx.message)
+        content = f'Added content flag filter for `{hashsum}`'
+        self.journal.send('content/new/flag', ctx.guild, content, icon='filter')
         await add_content_filter(
             self.bot,
             self.content_filters,
@@ -146,6 +148,8 @@ class Filtering:
         '''
 
         await check_hashsums((hashsum,), ctx.message)
+        content = f'Added content block filter for `{hashsum}`'
+        self.journal.send('content/new/block', ctx.guild, content, icon='filter')
         await add_content_filter(
             self.bot,
             self.content_filters,
@@ -167,6 +171,8 @@ class Filtering:
         '''
 
         await check_hashsums((hashsum,), ctx.message)
+        content = f'Added content jail filter for `{hashsum}`'
+        self.journal.send('content/new/jail', ctx.guild, content, icon='filter')
         await add_content_filter(
             self.bot,
             self.content_filters,
@@ -186,6 +192,8 @@ class Filtering:
         '''
 
         await check_hashsums(hashsums, ctx.message)
+        content = f'Removed content jail filter for `{hashsum}`'
+        self.journal.send('content/remove', ctx.guild, content, icon='filter')
         await delete_content_filter(self.bot, self.content_filters, ctx.message, hashsums)
 
     @filter.group(name='immune', aliases=['imm', 'ignore', 'ign'])

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -192,8 +192,9 @@ class Filtering:
         '''
 
         await check_hashsums(hashsums, ctx.message)
-        content = f'Removed content jail filter for `{hashsum}`'
-        self.journal.send('content/remove', ctx.guild, content, icon='filter')
+        str_hashsums = ' '.join(f'`{hashsum}`' for hashsum in hashsums)
+        content = f'Removed content jail filter for {str_hashsums}'
+        self.journal.send('content/remove', ctx.guild, content, icon='filter', hashsums=hashsums)
         await delete_content_filter(self.bot, self.content_filters, ctx.message, hashsums)
 
     @filter.group(name='immune', aliases=['imm', 'ignore', 'ign'])

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -94,9 +94,9 @@ class Filtering:
         if ctx.invoked_subcommand is None:
             raise SendHelp(ctx.command)
 
-    @commands.group(name='cfilter', aliases=['content', 'filefilter', 'ffilter'])
+    @commands.group(name='ffilter', aliases=['filefilter', 'content', 'cfilter'])
     @commands.guild_only()
-    async def cfilter(self, ctx):
+    async def ffilter(self, ctx):
         '''
         Adds, removes, or lists SHA1 hashes in the content filter.
         '''
@@ -104,19 +104,19 @@ class Filtering:
         if ctx.invoked_subcommand is None:
             raise SendHelp(ctx.command)
 
-    @cfilter.command(name='show', aliases=['display', 'list'])
+    @ffilter.command(name='show', aliases=['display', 'list'])
     @commands.guild_only()
-    async def cfilter_show(self, ctx):
+    async def ffilter_show(self, ctx):
         '''
         List all currently filtered SHA1 file hashes in the guild's filter.
         '''
 
         await show_content_filter(self.content_filters[ctx.guild], ctx.message)
 
-    @cfilter.command(name='flag', aliases=['warn', 'alert', 'notice'])
+    @ffilter.command(name='flag', aliases=['warn', 'alert', 'notice'])
     @commands.guild_only()
     @permissions.check_mod()
-    async def cfilter_flag(self, ctx, hashsum: str, description: str):
+    async def ffilter_flag(self, ctx, hashsum: str, description: str):
         '''
         Adds the given SHA1 hashes to the guild's flagging filter, which notifies staff when posted.
         It does not notify the user or delete the message.
@@ -136,10 +136,10 @@ class Filtering:
             description,
         )
 
-    @cfilter.command(name='block', aliases=['deny', 'autoremove'])
+    @ffilter.command(name='block', aliases=['deny', 'autoremove'])
     @commands.guild_only()
     @permissions.check_mod()
-    async def cfilter_block(self, ctx, hashsum: str, description: str):
+    async def ffilter_block(self, ctx, hashsum: str, description: str):
         '''
         Adds the given SHA1 hashes to the guild's blocking filter, automatically deleting any messages.
         It does not notify the user or delete the message.
@@ -159,10 +159,10 @@ class Filtering:
             description,
         )
 
-    @cfilter.command(name='jail', aliases=['dunce', 'punish', 'mute'])
+    @ffilter.command(name='jail', aliases=['dunce', 'punish', 'mute'])
     @commands.guild_only()
     @permissions.check_mod()
-    async def cfilter_jail(self, ctx, hashsum: str, description: str):
+    async def ffilter_jail(self, ctx, hashsum: str, description: str):
         '''
         Adds the given SHA1 hashes to the guild's jailing filter, which will automatically jail users.
         Like the blocking filter, it will also delete the message and send the user a warning.
@@ -182,10 +182,10 @@ class Filtering:
             description,
         )
 
-    @cfilter.command(name='remove', aliases=['rm', 'delete', 'del'])
+    @ffilter.command(name='remove', aliases=['rm', 'delete', 'del'])
     @commands.guild_only()
     @permissions.check_mod()
-    async def cfilter_remove(self, ctx, *hashsums: str):
+    async def ffilter_remove(self, ctx, *hashsums: str):
         '''
         Removes the given SHA1 hashes from the guild filter.
         You don't need to specify which filter level they were for.
@@ -373,12 +373,12 @@ class Filtering:
 
     @filter_channel.command(name='show', aliases=['display', 'list'])
     @commands.guild_only()
-    async def filter_channel_show(self, ctx):
+    async def filter_channel_show(self, ctx, channel: discord.TextChannel):
         '''
         List all currently filtered words in the channel filter.
         '''
 
-        await show_filter(self.filters[ctx.guild], ctx.message, ctx.author, ctx.guild.name)
+        await show_filter(self.filters[channel], ctx.message, ctx.author, channel.mention)
 
     @filter_channel.command(name='flag', aliases=['warn', 'alert', 'notice'])
     @commands.guild_only()

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -24,6 +24,7 @@ from discord.ext import commands
 
 from futaba import permissions
 from futaba.enums import FilterType, Reactions
+from futaba.exceptions import SendHelp
 from futaba.utils import async_partial, escape_backticks
 from .check import check_message, check_message_edit
 from .filter import Filter
@@ -91,8 +92,7 @@ class Filtering:
         '''
 
         if ctx.invoked_subcommand is None:
-            # TODO send help
-            await Reactions.FAIL.add(ctx.message)
+            raise SendHelp(ctx.command)
 
     @commands.group(name='cfilter', aliases=['content', 'filefilter', 'ffilter'])
     @commands.guild_only()
@@ -102,8 +102,7 @@ class Filtering:
         '''
 
         if ctx.invoked_subcommand is None:
-            # TODO send help
-            await Reactions.FAIL.add(ctx.message)
+            raise SendHelp(ctx.command)
 
     @cfilter.command(name='show', aliases=['display', 'list'])
     @commands.guild_only()
@@ -197,8 +196,7 @@ class Filtering:
         '''
 
         if ctx.subcommand_passed in ('immune', 'imm', 'ignore', 'ign'):
-            # TODO send help
-            await Reactions.FAIL.add(ctx.message)
+            raise SendHelp(ctx.command)
 
     @filter_immunity.command(name='add', aliases=['append', 'extend', 'new'])
     @commands.guild_only()
@@ -283,8 +281,7 @@ class Filtering:
         '''
 
         if ctx.subcommand_passed in ('server', 'srv', 's', 'guild', 'g'):
-            # TODO send help
-            await Reactions.FAIL.add(ctx.message)
+            raise SendHelp(ctx.command)
 
     @filter_guild.command(name='show', aliases=['display', 'list'])
     @commands.guild_only()
@@ -364,8 +361,7 @@ class Filtering:
         '''
 
         if ctx.subcommand_passed in ('chan', 'ch', 'c'):
-            # TODO send help
-            await Reactions.FAIL.add(ctx.message)
+            raise SendHelp(ctx.command)
 
     @filter_channel.command(name='show', aliases=['display', 'list'])
     @commands.guild_only()

--- a/futaba/cogs/filter/manage.py
+++ b/futaba/cogs/filter/manage.py
@@ -164,7 +164,6 @@ async def delete_content_filter(bot, filters, message, hexsums):
                     logger.debug("Filter was not present, not deleting")
     except Exception as error:
         logger.error("Error deleting filter(s)", exc_info=error)
-        success = False
         await Reactions.FAIL.add(message)
     else:
         await Reactions.SUCCESS.add(message)

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -25,7 +25,7 @@ from discord.ext import commands
 
 from futaba.enums import Reactions
 from futaba.parse import get_emoji, get_channel_id, get_role_id, get_user_id, similar_user_ids
-from futaba.permissions import check_mod_perm
+from futaba.permissions import mod_perm
 from futaba.str_builder import StringBuilder
 from futaba.utils import escape_backticks, fancy_timedelta, first, lowerbool, plural
 from futaba.unicode import UNICODE_CATEGORY_NAME
@@ -351,7 +351,7 @@ class Info:
 
         logger.info("Finding message IDs for dump: %s", ids)
 
-        if not check_mod_perm(ctx) and len(ids) > 3:
+        if not mod_perm(ctx) and len(ids) > 3:
             ids = islice(ids, 0, 3)
             await ctx.send(content='Too many messages requested, stopping at 3...')
 
@@ -412,7 +412,7 @@ class Info:
 
         logger.info("Finding message IDs for raws: %s", ids)
 
-        if not check_mod_perm(ctx) and len(ids) > 5:
+        if not mod_perm(ctx) and len(ids) > 5:
             ids = islice(ids, 0, 5)
             await ctx.send(content='Too many messages requested, stopping at 5...')
 

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -72,6 +72,7 @@ class Info:
             embed.set_thumbnail(url=emoji.url)
             embed.add_field(name='Name', value=emoji.name)
             embed.add_field(name='Guild', value=emoji.guild.name)
+            embed.add_field(name='ID', value=str(emoji.id))
             embed.add_field(name='Managed', value=lowerbool(emoji.managed))
             embed.timestamp = emoji.created_at
         elif isinstance(emoji, str):

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -23,6 +23,7 @@ from discord.ext import commands
 
 from futaba import permissions
 from futaba.enums import Reactions
+from futaba.exceptions import SendHelp
 from futaba.journal import ChannelOutputListener, Router
 from futaba.str_builder import StringBuilder
 
@@ -57,8 +58,7 @@ class Journal:
         ''' Configure channel output for bot journal events. '''
 
         if ctx.invoked_subcommand is None:
-            # TODO send help
-            await Reactions.FAIL.add(ctx.message)
+            raise SendHelp(ctx.command)
 
     @log.command(name='show', aliases=['display', 'list'])
     @commands.guild_only()

--- a/futaba/cogs/misc/core.py
+++ b/futaba/cogs/misc/core.py
@@ -164,9 +164,7 @@ class Miscellaneous:
     @commands.command(name='shutdown', aliases=['halt'])
     @permissions.check_owner()
     async def shutdown(self, ctx):
-        '''
-        Shuts down the bot. Only able to be run by an owner.
-        '''
+        ''' Shuts down the bot. Can only able be run by an owner. '''
 
         self.journal.send('admin/shutdown', ctx.guild, 'Shutting down bot', icon='shutdown')
         await Reactions.SUCCESS.add(ctx.message)

--- a/futaba/cogs/moderation/__init__.py
+++ b/futaba/cogs/moderation/__init__.py
@@ -18,6 +18,4 @@ def setup(bot):
     '''
 
     cog = Moderation(bot)
-    bot.add_listener(cog.member_ban, 'on_member_ban')
-    bot.add_listener(cog.member_kick, 'on_member_remove')
     bot.add_cog(cog)

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -55,7 +55,7 @@ class Reloader:
     @commands.command(name='load', aliases=['l'])
     @permissions.check_owner()
     async def load(self, ctx, cogname: str):
-        ''' Loads the given cog '''
+        ''' Loads the named cog. '''
 
         logger.info("Cog load requested: %s", cogname)
 
@@ -92,7 +92,7 @@ class Reloader:
     @commands.command(name='unload', aliases=['ul'])
     @permissions.check_owner()
     async def unload(self, ctx, cogname: str):
-        ''' Unloads the cog given '''
+        ''' Unloads the named cog. '''
 
         logger.info("Cog unload requested: %s", cogname)
 
@@ -129,7 +129,7 @@ class Reloader:
     @commands.command(name='reload', aliases=['rl'])
     @permissions.check_owner()
     async def reload(self, ctx, cogname: str):
-        ''' Reloads the cog given '''
+        ''' Reloads the named cog. '''
 
         logger.info("Cog reload requested: %s", cogname)
 
@@ -166,9 +166,7 @@ class Reloader:
 
     @commands.command(name='listcogs', aliases=['cogs'])
     async def listcogs(self, ctx):
-        '''
-        List the cogs that are currently loaded
-        '''
+        ''' Lists all currently loaded cogs. '''
 
         content = StringBuilder('```yaml\nCogs loaded:\n')
         if self.bot.cogs:

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -160,7 +160,7 @@ class Reloader:
             embed = discord.Embed(colour=discord.Colour.green(), description=f'```{cogname}```')
             embed.set_author(name='Reloaded')
             await asyncio.gather(
-                self.bot._send(embed=embed),
+                ctx.send(embed=embed),
                 Reactions.SUCCESS.add(ctx.message),
             )
 

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -74,7 +74,7 @@ class Reloader:
             self.load_cog(cogname)
         except Exception as error:
             logger.error("Loading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(colour=discord.Colour.red(), description=f'```{error}```')
+            embed = discord.Embed(colour=discord.Colour.red(), description=f'```\n{error}\n```')
             embed.set_author(name='Load failed')
             await asyncio.gather(
                 ctx.send(embed=embed),
@@ -82,7 +82,7 @@ class Reloader:
             )
         else:
             logger.info("Loaded cog: %s", cogname)
-            embed = discord.Embed(colour=discord.Colour.green(), description=f'```{cogname}```')
+            embed = discord.Embed(colour=discord.Colour.green(), description=f'```\n{cogname}\n```')
             embed.set_author(name='Loaded')
             await asyncio.gather(
                 ctx.send(embed=embed),
@@ -111,7 +111,7 @@ class Reloader:
             self.unload_cog(cogname)
         except Exception as error:
             logger.error("Unloading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(colour=discord.Colour.red(), description=f'```{error}```')
+            embed = discord.Embed(colour=discord.Colour.red(), description=f'```\n{error}\n```')
             embed.set_author(name='Unload failed')
             await asyncio.gather(
                 ctx.send(embed=embed),
@@ -119,7 +119,7 @@ class Reloader:
             )
         else:
             logger.info("Unloaded cog: %s", cogname)
-            embed = discord.Embed(colour=discord.Colour.green(), description=f'```{cogname}```')
+            embed = discord.Embed(colour=discord.Colour.green(), description=f'```\n{cogname}\n```')
             embed.set_author(name='Unloaded')
             await asyncio.gather(
                 ctx.send(embed=embed),
@@ -149,7 +149,7 @@ class Reloader:
             self.load_cog(cogname)
         except Exception as error:
             logger.error("Reloading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(colour=discord.Colour.red(), description=f'```{error}```')
+            embed = discord.Embed(colour=discord.Colour.red(), description=f'```\n{error}\n```')
             embed.set_author(name='Reload failed')
             await asyncio.gather(
                 ctx.send(embed=embed),
@@ -157,7 +157,7 @@ class Reloader:
             )
         else:
             logger.info("Reloaded cog: %s", cogname)
-            embed = discord.Embed(colour=discord.Colour.green(), description=f'```{cogname}```')
+            embed = discord.Embed(colour=discord.Colour.green(), description=f'```\n{cogname}\n```')
             embed.set_author(name='Reloaded')
             await asyncio.gather(
                 ctx.send(embed=embed),

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -61,7 +61,7 @@ class Reloader:
 
         if cogname in Reloader.MANDATORY_COGS:
             logger.info("Cog cannot be loaded because it is mandatory")
-            embed = discord.Embed(colour=discord.Colour.red())
+            embed = discord.Embed(colour=discord.Colour.dark_red())
             embed.set_author(name='Cannot load')
             embed.description = 'Cog cannot be loaded because it is mandatory'
             await asyncio.gather(
@@ -74,7 +74,7 @@ class Reloader:
             self.load_cog(cogname)
         except Exception as error:
             logger.error("Loading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(colour=discord.Colour.red(), description=f'```\n{error}\n```')
+            embed = discord.Embed(colour=discord.Colour.dark_red(), description=f'```\n{error}\n```')
             embed.set_author(name='Load failed')
             await asyncio.gather(
                 ctx.send(embed=embed),
@@ -98,7 +98,7 @@ class Reloader:
 
         if cogname in Reloader.MANDATORY_COGS:
             logger.info("Cog cannot be unloaded because it is mandatory")
-            embed = discord.Embed(colour=discord.Colour.red())
+            embed = discord.Embed(colour=discord.Colour.dark_red())
             embed.set_author(name='Cannot unload')
             embed.description = 'Cog cannot be unloaded because it is mandatory'
             await asyncio.gather(
@@ -111,7 +111,7 @@ class Reloader:
             self.unload_cog(cogname)
         except Exception as error:
             logger.error("Unloading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(colour=discord.Colour.red(), description=f'```\n{error}\n```')
+            embed = discord.Embed(colour=discord.Colour.dark_red(), description=f'```\n{error}\n```')
             embed.set_author(name='Unload failed')
             await asyncio.gather(
                 ctx.send(embed=embed),
@@ -135,7 +135,7 @@ class Reloader:
 
         if cogname in Reloader.MANDATORY_COGS:
             logger.info("Cog cannot be reloaded because it is mandatory")
-            embed = discord.Embed(colour=discord.Colour.red())
+            embed = discord.Embed(colour=discord.Colour.dark_red())
             embed.set_author(name='Cannot reload')
             embed.description = 'Cog cannot be reloaded because it is mandatory'
             await asyncio.gather(
@@ -149,7 +149,7 @@ class Reloader:
             self.load_cog(cogname)
         except Exception as error:
             logger.error("Reloading cog %s failed", cogname, exc_info=error)
-            embed = discord.Embed(colour=discord.Colour.red(), description=f'```\n{error}\n```')
+            embed = discord.Embed(colour=discord.Colour.dark_red(), description=f'```\n{error}\n```')
             embed.set_author(name='Reload failed')
             await asyncio.gather(
                 ctx.send(embed=embed),

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -22,6 +22,10 @@ import discord
 from discord.ext import commands
 
 from futaba import permissions
+from futaba.emojis import ICONS
+from futaba.enums import Reactions
+from futaba.parse import get_role_id
+from futaba.utils import escape_backticks
 
 logger = logging.getLogger(__name__)
 
@@ -37,4 +41,166 @@ class Settings:
     def __init__(self, bot):
         self.bot = bot
 
-    # TODO
+        for guild in bot.guilds:
+            bot.sql.settings.get_special_roles(guild)
+
+    @commands.command(name='specroles', aliases=['sroles'])
+    @commands.guild_only()
+    async def special_roles(self, ctx):
+        ''' Retrieves all configured roles for this guild. '''
+
+        logger.info("Sending list of all configured roles for guild '%s' (%d)",
+                ctx.guild.name, ctx.guild.id)
+
+        roles = self.bot.sql.settings.get_special_roles(ctx.guild)
+        mention = lambda role: getattr(role, 'mention', '(none)')
+
+        embed = discord.Embed(colour=discord.Colour.dark_teal())
+        embed.description = '\n'.join((
+            f'{ICONS["member"]} Member: {mention(roles.member)}',
+            f'{ICONS["guest"]} Guest: {mention(roles.guest)}',
+            f'{ICONS["mute"]} Mute: {mention(roles.mute)}',
+            f'{ICONS["jail"]} Jail: {mention(roles.jail)}',
+        ))
+
+        await asyncio.gather(
+            ctx.send(embed=embed),
+            Reactions.SUCCESS.add(ctx.message),
+        )
+
+    async def get_role(self, ctx, name, check_roles=True):
+        role_id = get_role_id(name, ctx.guild.roles)
+        role = discord.utils.get(ctx.guild.roles, id=role_id)
+        embed = discord.Embed(colour=discord.Colour.dark_red())
+        if role is None:
+            embed.description = 'No role with description `{escape_backticks(name)}` found'
+            await asyncio.gather(
+                ctx.send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+            return None
+        elif role.is_default():
+            embed.description = '@everyone role cannot be assigned for this purpose'
+            await asyncio.gather(
+                ctx.send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+            return None
+        elif check_roles:
+            special_roles = self.bot.sql.settings.get_special_roles(ctx.guild)
+            if role in special_roles:
+                embed.description = f'Cannot assign the same role for multiple purposes'
+                await asyncio.gather(
+                    ctx.send(embed=embed),
+                    Reactions.FAIL.add(ctx.message),
+                )
+                return None
+        else:
+            return role
+
+    @commands.command(name='setmember')
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def set_member_role(self, ctx, *, name: str = None):
+        ''' Set the member role for this guild. No argument to unset. '''
+
+        logger.info("Setting member role for guild '%s' (%d) to '%s",
+                ctx.guild.name, ctx.guild.id, name)
+
+        if name is None:
+            role = None
+        else:
+            role = await self.get_role(ctx, name)
+            if role is None:
+                return
+
+        with self.bot.sql.transaction():
+            self.bot.sql.settings.set_special_roles(ctx.guild, member_role=role)
+
+        if role:
+            content = f'Set member role to {role.mention}'
+        else:
+            content = 'Unset member role'
+
+        await asyncio.gather(
+            ctx.send(content=content),
+            Reactions.SUCCESS.add(ctx.message),
+        )
+
+    @commands.command(name='setguest')
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def set_guest_role(self, ctx, *, name: str):
+        ''' Set the guest role for this guild. '''
+
+        logger.info("Setting guest role for guild '%s' (%d) to '%s",
+                ctx.guild.name, ctx.guild.id, name)
+
+        if name is None:
+            role = None
+        else:
+            role = await self.get_role(ctx, name)
+            if role is None:
+                return
+
+        with self.bot.sql.transaction():
+            self.bot.sql.settings.set_special_roles(ctx.guild, guest_role=role)
+
+        if role:
+            content = f'Set guest role to {role.mention}'
+        else:
+            content = 'Unset guest role'
+
+        await Reactions.SUCCESS.add(ctx.message)
+
+    @commands.command(name='setmute')
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def set_mute_role(self, ctx, *, name: str):
+        ''' Set the mute role for this guild. '''
+
+        logger.info("Setting mute role for guild '%s' (%d) to '%s",
+                ctx.guild.name, ctx.guild.id, name)
+
+        if name is None:
+            role = None
+        else:
+            role = await self.get_role(ctx, name)
+            if role is None:
+                return
+
+        with self.bot.sql.transaction():
+            self.bot.sql.settings.set_special_roles(ctx.guild, mute_role=role)
+
+        if role:
+            content = f'Set mute role to {role.mention}'
+        else:
+            content = 'Unset mute role'
+
+        await Reactions.SUCCESS.add(ctx.message)
+
+    @commands.command(name='setjail')
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def set_jail_role(self, ctx, *, name: str):
+        ''' Set the mute role for this guild. '''
+
+        logger.info("Setting mute role for guild '%s' (%d) to '%s",
+                ctx.guild.name, ctx.guild.id, name)
+
+        if name is None:
+            role = None
+        else:
+            role = await self.get_role(ctx, name)
+            if role is None:
+                return
+
+        with self.bot.sql.transaction():
+            self.bot.sql.settings.set_special_roles(ctx.guild, mute_role=role)
+
+        if role:
+            content = f'Set jail role to {role.mention}'
+        else:
+            content = 'Unset jail role'
+
+        await Reactions.SUCCESS.add(ctx.message)

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -115,15 +115,16 @@ class Settings:
                 return
 
         with self.bot.sql.transaction():
-            self.bot.sql.settings.set_special_roles(ctx.guild, member_role=role)
+            self.bot.sql.settings.set_special_roles(ctx.guild, member=role)
 
+        embed = discord.Embed(colour=discord.Colour.green())
         if role:
-            content = f'Set member role to {role.mention}'
+            embed.description = f'Set member role to {role.mention}'
         else:
-            content = 'Unset member role'
+            embed.description = 'Unset member role'
 
         await asyncio.gather(
-            ctx.send(content=content),
+            ctx.send(embed=embed),
             Reactions.SUCCESS.add(ctx.message),
         )
 
@@ -144,14 +145,18 @@ class Settings:
                 return
 
         with self.bot.sql.transaction():
-            self.bot.sql.settings.set_special_roles(ctx.guild, guest_role=role)
+            self.bot.sql.settings.set_special_roles(ctx.guild, guest=role)
 
+        embed = discord.Embed(colour=discord.Colour.green())
         if role:
-            content = f'Set guest role to {role.mention}'
+            embed.description = f'Set guest role to {role.mention}'
         else:
-            content = 'Unset guest role'
+            embed.description = 'Unset guest role'
 
-        await Reactions.SUCCESS.add(ctx.message)
+        await asyncio.gather(
+            ctx.send(embed=embed),
+            Reactions.SUCCESS.add(ctx.message),
+        )
 
     @commands.command(name='setmute')
     @commands.guild_only()
@@ -170,14 +175,18 @@ class Settings:
                 return
 
         with self.bot.sql.transaction():
-            self.bot.sql.settings.set_special_roles(ctx.guild, mute_role=role)
+            self.bot.sql.settings.set_special_roles(ctx.guild, mute=role)
 
+        embed = discord.Embed(colour=discord.Colour.green())
         if role:
-            content = f'Set mute role to {role.mention}'
+            embed.description = f'Set mute role to {role.mention}'
         else:
-            content = 'Unset mute role'
+            embed.description = 'Unset mute role'
 
-        await Reactions.SUCCESS.add(ctx.message)
+        await asyncio.gather(
+            ctx.send(embed=embed),
+            Reactions.SUCCESS.add(ctx.message),
+        )
 
     @commands.command(name='setjail')
     @commands.guild_only()
@@ -196,11 +205,15 @@ class Settings:
                 return
 
         with self.bot.sql.transaction():
-            self.bot.sql.settings.set_special_roles(ctx.guild, mute_role=role)
+            self.bot.sql.settings.set_special_roles(ctx.guild, jail=role)
 
+        embed = discord.Embed(colour=discord.Colour.green())
         if role:
-            content = f'Set jail role to {role.mention}'
+            embed.description = f'Set jail role to {role.mention}'
         else:
-            content = 'Unset jail role'
+            embed.description = 'Unset jail role'
 
-        await Reactions.SUCCESS.add(ctx.message)
+        await asyncio.gather(
+            ctx.send(embed=embed),
+            Reactions.SUCCESS.add(ctx.message),
+        )

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -68,12 +68,12 @@ class Settings:
             Reactions.SUCCESS.add(ctx.message),
         )
 
-    async def get_role(self, ctx, name, check_roles=True):
+    async def get_role(self, ctx, name):
         role_id = get_role_id(name, ctx.guild.roles)
         role = discord.utils.get(ctx.guild.roles, id=role_id)
         embed = discord.Embed(colour=discord.Colour.dark_red())
         if role is None:
-            embed.description = 'No role with description `{escape_backticks(name)}` found'
+            embed.description = f'No role with description `{escape_backticks(name)}` found'
             await asyncio.gather(
                 ctx.send(embed=embed),
                 Reactions.FAIL.add(ctx.message),
@@ -86,17 +86,17 @@ class Settings:
                 Reactions.FAIL.add(ctx.message),
             )
             return None
-        elif check_roles:
-            special_roles = self.bot.sql.settings.get_special_roles(ctx.guild)
-            if role in special_roles:
-                embed.description = f'Cannot assign the same role for multiple purposes'
-                await asyncio.gather(
-                    ctx.send(embed=embed),
-                    Reactions.FAIL.add(ctx.message),
-                )
-                return None
-        else:
-            return role
+
+        special_roles = self.bot.sql.settings.get_special_roles(ctx.guild)
+        if role in special_roles:
+            embed.description = f'Cannot assign the same role for multiple purposes'
+            await asyncio.gather(
+                ctx.send(embed=embed),
+                Reactions.FAIL.add(ctx.message),
+            )
+            return None
+
+        return role
 
     @commands.command(name='setmember')
     @commands.guild_only()
@@ -104,7 +104,7 @@ class Settings:
     async def set_member_role(self, ctx, *, name: str = None):
         ''' Set the member role for this guild. No argument to unset. '''
 
-        logger.info("Setting member role for guild '%s' (%d) to '%s",
+        logger.info("Setting member role for guild '%s' (%d) to '%s'",
                 ctx.guild.name, ctx.guild.id, name)
 
         if name is None:
@@ -131,10 +131,10 @@ class Settings:
     @commands.command(name='setguest')
     @commands.guild_only()
     @permissions.check_mod()
-    async def set_guest_role(self, ctx, *, name: str):
-        ''' Set the guest role for this guild. '''
+    async def set_guest_role(self, ctx, *, name: str = None):
+        ''' Set the guest role for this guild. No argument to unset. '''
 
-        logger.info("Setting guest role for guild '%s' (%d) to '%s",
+        logger.info("Setting guest role for guild '%s' (%d) to '%s'",
                 ctx.guild.name, ctx.guild.id, name)
 
         if name is None:
@@ -161,10 +161,10 @@ class Settings:
     @commands.command(name='setmute')
     @commands.guild_only()
     @permissions.check_mod()
-    async def set_mute_role(self, ctx, *, name: str):
-        ''' Set the mute role for this guild. '''
+    async def set_mute_role(self, ctx, *, name: str = None):
+        ''' Set the mute role for this guild. No argument to unset. '''
 
-        logger.info("Setting mute role for guild '%s' (%d) to '%s",
+        logger.info("Setting mute role for guild '%s' (%d) to '%s'",
                 ctx.guild.name, ctx.guild.id, name)
 
         if name is None:
@@ -191,10 +191,10 @@ class Settings:
     @commands.command(name='setjail')
     @commands.guild_only()
     @permissions.check_mod()
-    async def set_jail_role(self, ctx, *, name: str):
-        ''' Set the mute role for this guild. '''
+    async def set_jail_role(self, ctx, *, name: str = None):
+        ''' Set the mute role for this guild. No argument to unset. '''
 
-        logger.info("Setting mute role for guild '%s' (%d) to '%s",
+        logger.info("Setting mute role for guild '%s' (%d) to '%s'",
                 ctx.guild.name, ctx.guild.id, name)
 
         if name is None:

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -17,6 +17,7 @@ of configured settings in between runs of the bot.
 
 import asyncio
 import logging
+import re
 
 import discord
 from discord.ext import commands
@@ -25,6 +26,7 @@ from futaba import permissions
 from futaba.emojis import ICONS
 from futaba.enums import Reactions
 from futaba.parse import get_role_id
+from futaba.permissions import mod_perm
 from futaba.utils import escape_backticks
 
 logger = logging.getLogger(__name__)
@@ -43,6 +45,58 @@ class Settings:
 
         for guild in bot.guilds:
             bot.sql.settings.get_special_roles(guild)
+
+    @commands.command(name='prefix')
+    async def prefix(self, ctx, *, prefix: str = None):
+        '''
+        Gets the current prefix. If you're a moderator, you can set it too.
+        A trailing underscore is converted into spaces. A single '_' unsets
+        the bot's prefix, and uses the default one.
+        '''
+
+        # Attempt to set prefix outside of guild
+        if ctx.guild is None and prefix is None:
+            embed = discord.Embed(colour=discord.Colour.dark_red())
+            embed.description = 'Cannot set a bot prefix outside of a server!'
+            reaction = Reactions.FAIL
+
+        # Get prefix
+        elif prefix is None:
+            bot_prefix = self.bot.prefix(ctx.message)
+            embed = discord.Embed(colour=discord.Colour.dark_teal())
+            embed.description = f'Prefix for {ctx.guild.name} is `{bot_prefix}`'
+            reaction = Reactions.SUCCESS
+
+        # Unset prefix
+        elif prefix == '_':
+            with self.bot.sql.transaction():
+                self.bot.sql.settings.set_prefix(ctx.guild, None)
+                bot_prefix = self.bot.prefix(ctx.message)
+
+            embed = discord.Embed(colour=discord.Colour.dark_teal())
+            embed.description = f'Unset prefix for {ctx.guild.name}. (Default prefix: `{bot_prefix}`)'
+            reaction = Reactions.SUCCESS
+
+        # Lacking authority to set prefix
+        elif not mod_perm(ctx):
+            embed = discord.Embed(colour=discord.Colour.dark_red())
+            embed.description = 'You do not have permission to set the prefix'
+            reaction = Reactions.DENY
+
+        # Set prefix
+        else:
+            bot_prefix = re.sub(r'_$', ' ', prefix)
+            with self.bot.sql.transaction():
+                self.bot.sql.settings.set_prefix(ctx.guild, bot_prefix)
+
+            embed = discord.Embed(colour=discord.Colour.dark_teal())
+            embed.description = f'Set prefix for {ctx.guild.name} to `{bot_prefix}`'
+            reaction = Reactions.SUCCESS
+
+        await asyncio.gather(
+            ctx.send(embed=embed),
+            reaction.add(ctx.message),
+        )
 
     @commands.command(name='specroles', aliases=['sroles'])
     @commands.guild_only()

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -54,18 +54,21 @@ class Settings:
         the bot's prefix, and uses the default one.
         '''
 
-        # Attempt to set prefix outside of guild
-        if ctx.guild is None and prefix is None:
-            embed = discord.Embed(colour=discord.Colour.dark_red())
-            embed.description = 'Cannot set a bot prefix outside of a server!'
-            reaction = Reactions.FAIL
-
         # Get prefix
-        elif prefix is None:
+        if prefix is None:
             bot_prefix = self.bot.prefix(ctx.message)
             embed = discord.Embed(colour=discord.Colour.dark_teal())
-            embed.description = f'Prefix for {ctx.guild.name} is `{bot_prefix}`'
+            if ctx.guild is None:
+                embed.description = 'No command prefix, all messages are commands.'
+            else:
+                embed.description = f'Prefix for {ctx.guild.name} is `{bot_prefix}`.'
             reaction = Reactions.SUCCESS
+
+        # Attempt to set prefix outside of guild
+        elif ctx.guild is None and prefix is not None:
+            embed = discord.Embed(colour=discord.Colour.dark_red())
+            embed.description = 'Cannot set a command prefix outside of a server!'
+            reaction = Reactions.FAIL
 
         # Unset prefix
         elif prefix == '_':

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -42,6 +42,8 @@ LISTENERS = (
     'on_reaction_clear',
     'on_guild_channel_create',
     'on_guild_channel_delete',
+    'on_member_join',
+    'on_member_remove',
 )
 
 class Tracker:
@@ -175,3 +177,16 @@ class Tracker:
         logger.debug("Channel #%s (%d) was deleted", channel.name, channel.id)
         content = f'Guild channel #{channel.name} ({channel.id}) deleted'
         self.journal.send('channel/delete', channel.guild, content, icon='delete')
+
+    async def on_member_join(self, member):
+        logger.debug("Member %s (%d) joined '%s' (%d)",
+                member.name, member.id, member.guild.name, member.guild.id)
+        content = f'Member {member.mention} ({user_discrim(member)} {member.id}) joined'
+        self.journal.send('member/join', member.guild, content, icon='join', member=member)
+
+    async def on_member_remove(self, member):
+        logger.debug("Member %s (%d) left '%s' (%d)",
+                member.name, member.id, member.guild.name, member.guild.id)
+        content = f'Member {member.mention} ({user_discrim(member)} {member.id}) left'
+        self.journal.send('member/leave', member.guild, content,
+                icon='join', member=member)

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -129,7 +129,7 @@ class Tracker:
         self.journal.send('message/edit', after.guild, content, icon='edit',
                 before=before, after=after)
         self.journal.send('jump/message/edit', after.guild, after.jump_url,
-                icon='previous', message=message)
+                icon='previous', before=before, after=after)
 
     async def on_message_delete(self, message):
         if message.guild is None:
@@ -257,7 +257,7 @@ class Tracker:
         # Wait for a bit so we can catch the audit log entry
         timestamp = datetime.now()
         await asyncio.sleep(5)
-        cause = await get_removal_cause(member, timestamp)
+        cause = await self.get_removal_cause(member, timestamp)
 
         content = f'Member {member.mention} ({user_discrim(member)} {member.id}) left'
         self.journal.send('member/leave', member.guild, content,

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -85,7 +85,8 @@ class Tracker:
                 user.name, user.id, channel.name, channel.id)
 
         content = f'{user.name}#{user.discriminator} ({user.id}) is typing in {channel.mention}'
-        self.journal.send('typing', channel.guild, content, icon='typing')
+        self.journal.send('typing', channel.guild, content,
+                icon='typing', channel=channel, user=user, when=when)
 
     async def on_message(self, message):
         if message in self.new_messages:
@@ -100,8 +101,9 @@ class Tracker:
                 message.author.name, message.author.id, message.channel.name, message.channel.id)
 
         content = f'{user_discrim(message.author)} sent a message in {message.channel.mention}'
-        self.journal.send('message/new', message.guild, content, icon='message')
-        self.journal.send('jump/message/new', message.guild, message.jump_url, icon='previous')
+        self.journal.send('message/new', message.guild, content, icon='message', message=message)
+        self.journal.send('jump/message/new', message.guild, message.jump_url,
+                icon='previous', message=message)
 
     async def on_message_edit(self, before, after):
         if after in self.edited_messages:
@@ -116,17 +118,21 @@ class Tracker:
                 after.id, after.author.name, after.author.id, after.channel.name, after.channel.id)
 
         content = f'{user_discrim(after.author)} edited message {after.id} in {after.channel.mention}'
-        self.journal.send('message/edit', after.guild, content, icon='edit')
-        self.journal.send('jump/message/edit', after.guild, after.jump_url, icon='previous')
+        self.journal.send('message/edit', after.guild, content, icon='edit',
+                before=before, after=after)
+        self.journal.send('jump/message/edit', after.guild, after.jump_url,
+                icon='previous', message=message)
 
     async def on_message_delete(self, message):
         if message.guild is None:
             return
 
-        logger.debug("Message %d by %s (%d) was deleted", message.id, message.author.name, message.author.id)
+        logger.debug("Message %d by %s (%d) was deleted",
+                message.id, message.author.name, message.author.id)
         content = f'Message {message.id} by {user_discrim(message.author)} was deleted'
-        self.journal.send('message/delete', message.guild, content, icon='delete')
-        self.journal.send('jump/message/delete', message.guild, message.jump_url, icon='previous')
+        self.journal.send('message/delete', message.guild, content, icon='delete', message=message)
+        self.journal.send('jump/message/delete', message.guild, message.jump_url,
+                icon='previous', message=message)
 
     async def on_reaction_add(self, reaction, user):
         if (reaction, user) in self.reactions:
@@ -143,8 +149,10 @@ class Tracker:
 
         logger.debug("Reaction %s added to message %d by %s (%d)", emoji, message.id, user.name, user.id)
         content = f'{user_discrim(user)} added reaction {emoji} to message {message.id} in {channel.mention}'
-        self.journal.send('reaction/add', message.guild, content, icon='item_add')
-        self.journal.send('jump/reaction/add', message.guild, message.jump_url, icon='previous')
+        self.journal.send('reaction/add', message.guild, content,
+                icon='item_add', reaction=reaction, user=user)
+        self.journal.send('jump/reaction/add', message.guild, message.jump_url,
+                icon='previous', message=message)
 
     async def on_reaction_remove(self, reaction, user):
         message = reaction.message
@@ -156,8 +164,10 @@ class Tracker:
 
         logger.debug("Reaction %s removed to message %d by %s (%d)", emoji, message.id, user.name, user.id)
         content = f'{user_discrim(user)} removed reaction {emoji} from message {message.id} in {channel.mention}'
-        self.journal.send('reaction/remove', message.guild, content, icon='item_remove')
-        self.journal.send('jump/reaction/remove', message.guild, message.jump_url, icon='previous')
+        self.journal.send('reaction/remove', message.guild, content,
+                icon='item_remove', reaction=reaction, user=user)
+        self.journal.send('jump/reaction/remove', message.guild, message.jump_url,
+                icon='previous', message=message)
 
     async def on_reaction_clear(self, message, reactions):
         if message.guild is None:
@@ -165,18 +175,20 @@ class Tracker:
 
         logger.debug("All reactions from message %d were removed", message.id)
         content = f'All reactions on message {message.id} in {message.channel.mention} were removed'
-        self.journal.send('reaction/clear', message.guild, content, icon='item_clear')
-        self.journal.send('jump/reaction/clear', message.guild, message.jump_url, icon='previous')
+        self.journal.send('reaction/clear', message.guild, content, icon='item_clear',
+                message=message, reactions=reactions)
+        self.journal.send('jump/reaction/clear', message.guild, message.jump_url,
+                icon='previous', message=message)
 
     async def on_guild_channel_create(self, channel):
         logger.debug("Channel #%s (%d) was created", channel.name, channel.id)
         content = f'Guild channel {channel.mention} created'
-        self.journal.send('channel/new', channel.guild, content, icon='channel')
+        self.journal.send('channel/new', channel.guild, content, icon='channel', channel=channel)
 
     async def on_guild_channel_delete(self, channel):
         logger.debug("Channel #%s (%d) was deleted", channel.name, channel.id)
         content = f'Guild channel #{channel.name} ({channel.id}) deleted'
-        self.journal.send('channel/delete', channel.guild, content, icon='delete')
+        self.journal.send('channel/delete', channel.guild, content, icon='delete', channel=channel)
 
     async def on_member_join(self, member):
         logger.debug("Member %s (%d) joined '%s' (%d)",

--- a/futaba/cogs/welcome/__init__.py
+++ b/futaba/cogs/welcome/__init__.py
@@ -1,0 +1,23 @@
+#
+# cogs/welcome/__init__.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+from .core import Welcome
+
+def setup(bot):
+    '''
+    Setup for bot to add cog
+    '''
+
+    cog = Welcome(bot)
+    bot.add_listener(cog.member_join, 'on_member_join')
+    bot.add_listener(cog.member_leave, 'on_member_remove')
+    bot.add_cog(cog)

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -96,7 +96,7 @@ class Welcome:
         if welcome.goodbye_message and welcome.channel:
             await self.send_welcome_message(member, welcome.goodbye_message, welcome.channel)
 
-    @commands.command(name='agree', aliases=['accept'])
+    @commands.command(name='agree', aliases=['accept'], hidden=True)
     @commands.guild_only()
     async def agree(self, ctx):
         '''

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -45,7 +45,7 @@ Accepted parameters:
 {mention}      - Text mentioning the user.
 {user}         - The user's name. Does not include nicknames.
 {discrim}      - The user's discriminator.
-{userdiscrim}  - Username and discriminator, in the style of "user#1000".
+{user_discrim} - Username and discriminator, in the style of "user#1000".
 {user_id}      - The user's discord ID.
 {channel}      - Text mentioning the welcome channel.
 {channel_name} - The name of the welcome channel. No "#" in front.
@@ -67,7 +67,7 @@ def format_message(welcome_message, ctx):
         mention=user.mention,
         user=user.name,
         discrim=user.discriminator,
-        userdiscrim=user_discrim(user),
+        user_discrim=user_discrim(user),
         user_id=user.id,
         channel=channel.mention,
         channel_name=channel.name,

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -16,6 +16,7 @@ Cog for greeting new members, accepting !agree commands, and applying Member and
 
 import asyncio
 import logging
+import re
 from collections import deque, namedtuple
 
 import discord
@@ -23,20 +24,41 @@ from discord.ext import commands
 
 from futaba import permissions
 from futaba.enums import Reactions
-from futaba.exceptions import InvalidCommandContext, SendHelp
+from futaba.exceptions import CommandFailed, InvalidCommandContext, SendHelp
+from futaba.journal import ModerationListener
 from futaba.utils import user_discrim
 
 FakeContext = namedtuple('FakeContext', ('author', 'channel', 'guild'))
 logger = logging.getLogger(__package__)
 
 __all__ = [
-    'format_welcome_message',
+    'format_message',
     'Welcome',
 ]
 
 AGREE_REASON = "User agreed to the server's rules and policies"
+FORMAT_HELP_LIST = \
+'''
+If you want to send a literal `{` or `}`, send `{{` / `}}`.
+Accepted parameters:
+```
+{mention}      - Text mentioning the user.
+{user}         - The user's name. Does not include nicknames.
+{discrim}      - The user's discriminator.
+{userdiscrim}  - Username and discriminator, in the style of "user#1000".
+{user_id}      - The user's discord ID.
+{channel}      - Text mentioning the welcome channel.
+{channel_name} - The name of the welcome channel. No "#" in front.
+{channel_id}   - The welcome channel's discord ID.
+{server}       - The server's name. Also aliased as {guild}.
+{server_id}    - The server's discord ID. Also aliased as {guild_id}.
+```
+'''
 
-def format_welcome_message(welcome_message, ctx):
+MESSAGE_HIGHLIGHT_REGEX = re.compile(r'(\{[^\{\}]+\})')
+message_highlight = lambda s: '\n' + MESSAGE_HIGHLIGHT_REGEX.sub(r'`\1`', s) if s else '(none)'
+
+def format_message(welcome_message, ctx):
     user = ctx.author
     channel = ctx.channel
     guild = ctx.guild
@@ -68,11 +90,47 @@ class Welcome:
         self.journal = bot.get_broadcaster('/welcome')
         self.recently_joined = deque(maxlen=5)
 
+        self.add_listener()
+
+        for guild in bot.guilds:
+            bot.sql.welcome.get_welcome(guild)
+
+    def add_listener(self):
+        # Check if a moderation listener is already in place
+        router = self.journal.router
+        for listener in router.paths['/member/leave']:
+            if isinstance(listener, ModerationListener):
+                return
+
+        # If not, add listener
+        router.register(ModerationListener(router, self.bot))
+
     @staticmethod
-    async def send_welcome_message(member, format_message, channel):
+    async def send_welcome_message(member, fmt_message, channel):
         ctx = FakeContext(author=member, channel=channel, guild=member.guild)
-        content = format_welcome_message(format_message, ctx)
+        content = format_message(fmt_message, ctx)
         await channel.send(content=content)
+
+    @staticmethod
+    async def check_welcome_message(ctx, fmt_message):
+        response = None
+
+        try:
+            format_message(fmt_message, ctx)
+        except ValueError as error:
+            response = str(error)
+        except KeyError as error:
+            response = f'No such format parameter: {error}'
+        except IndexError:
+            response = 'Invalid syntax'
+
+        if response is not None:
+            await asyncio.gather(
+                ctx.send(content=response),
+                Reactions.FAIL.add(ctx.message),
+            )
+            # TODO remove above when command exception handling stuff is added
+            raise CommandFailed(content=response)
 
     async def member_join(self, member):
         logger.info("Member %s (%d) joined '%s' (%d)",
@@ -143,12 +201,17 @@ class Welcome:
             tasks.append(ctx.author.remove_roles(roles.guest, reason=AGREE_REASON))
 
         if welcome.agreed_message:
-            tasks.append(ctx.send(content=format_welcome_message(welcome.agreed_message, ctx)))
+            tasks.append(ctx.send(content=format_message(welcome.agreed_message, ctx)))
 
         # TODO: restore old roles
 
         # Run all tasks in parallel
         await asyncio.gather(*tasks)
+
+        # Send journal event
+        agreer = f'{ctx.author.mention} ({user_discrim(ctx.author)})'
+        content = f'User {agreer} has agreed to the rules and information'
+        self.journal.send('member/agree', ctx.guild, content, icon='agree', user=ctx.author)
 
         # Prevent the bot from attempting to add a success reaction
         if welcome.delete_on_agree:
@@ -213,5 +276,104 @@ class Welcome:
         content = f'{user_discrim(ctx.author)} unset the welcome channel'
         self.journal.send('channel/set', ctx.guild, content, icon='settings',
                 channel=None, cause=ctx.author)
+
+        await Reactions.SUCCESS.add(ctx.message)
+
+    @welcome.command(name='format')
+    async def format(self, ctx):
+        ''' Lists all parameters accepted when formatting welcome messages. '''
+
+        logger.info("Sending list of accepted format parameters to %s (%d)",
+                ctx.author.name, ctx.author.id)
+
+        try:
+            await ctx.author.send(content=FORMAT_HELP_LIST)
+        except discord.Forbidden:
+            await asyncio.gather(
+                ctx.send(content="I don't have permission to DM you"),
+                Reactions.FAIL.add(ctx.message),
+            )
+        else:
+            await Reactions.SUCCESS.add(ctx.message)
+
+    @welcome.command(name='getmsg')
+    @commands.guild_only()
+    async def get_messages(self, ctx):
+        ''' Retrieves all configured welcome messages for this guild. '''
+
+        logger.info("Sending list of all configured welcome messages for guild '%s' (%d)",
+                ctx.guild.name, ctx.guild.id)
+
+        welcome = self.bot.sql.welcome.get_welcome(ctx.guild)
+        welcome_message = message_highlight(welcome.welcome_message)
+        goodbye_message = message_highlight(welcome.goodbye_message)
+        agreed_message = message_highlight(welcome.agreed_message)
+
+        embed = discord.Embed(colour=discord.Colour.dark_teal())
+        embed.description = '\n'.join((
+            f'**Welcome message**: {welcome_message}',
+            f'**Goodbye message**: {goodbye_message}',
+            f'**Agree message**: {agreed_message}',
+        ))
+
+        await asyncio.gather(
+            ctx.send(embed=embed),
+            Reactions.SUCCESS.add(ctx.message),
+        )
+
+    @welcome.command(name='welcomemsg')
+    @commands.guild_only()
+    @permissions.check_admin()
+    async def set_welcome_message(self, ctx, *, welcome_message: str = None):
+        '''
+        Sets the welcome message to newly joined users. No argument to unset.
+        '''
+
+        logger.info("Setting the welcome message in guild '%s' (%d): %r",
+                ctx.guild.name, ctx.guild.id, welcome_message)
+
+        if welcome_message is not None:
+            await self.check_welcome_message(ctx, welcome_message)
+
+        with self.bot.sql.transaction():
+            self.bot.sql.welcome.set_welcome_message(ctx.guild, welcome_message or None)
+
+        await Reactions.SUCCESS.add(ctx.message)
+
+    @welcome.command(name='goodbyemsg')
+    @commands.guild_only()
+    @permissions.check_admin()
+    async def set_goodbye_message(self, ctx, *, goodbye_message: str = None):
+        '''
+        Sets the goodbye message for departing users. No argument to unset.
+        '''
+
+        logger.info("Setting the goodbye message in guild '%s' (%d): %r",
+                ctx.guild.name, ctx.guild.id, goodbye_message)
+
+        if goodbye_message is not None:
+            await self.check_welcome_message(ctx, goodbye_message)
+
+        with self.bot.sql.transaction():
+            self.bot.sql.welcome.set_goodbye_message(ctx.guild, goodbye_message or None)
+
+        await Reactions.SUCCESS.add(ctx.message)
+
+    @welcome.command(name='agreemsg')
+    @commands.guild_only()
+    @permissions.check_admin()
+    async def set_agreed_message(self, ctx, *, agreed_message: str = None):
+        '''
+        Sets the message for users who have agreed to the rules. No argument to unset.
+        '''
+
+        logger.info("Setting the agree message in guild '%s' (%d): %r",
+                ctx.guild.name, ctx.guild.id, agreed_message)
+
+        if agreed_message is not None:
+            await self.check_welcome_message(ctx, agreed_message)
+
+        with self.bot.sql.transaction():
+            self.bot.sql.welcome.set_agreed_message(ctx.guild, agreed_message)
 
         await Reactions.SUCCESS.add(ctx.message)

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -1,0 +1,139 @@
+#
+# cogs/welcome/core.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Cog for greeting new members, accepting !agree commands, and applying Member and Guest roles.
+'''
+
+import asyncio
+import logging
+from collections import deque, namedtuple
+
+import discord
+from discord.ext import commands
+
+from futaba.exceptions import InvalidCommandContext
+from futaba.utils import user_discrim
+
+FakeContext = namedtuple('FakeContext', ('author', 'channel', 'guild'))
+logger = logging.getLogger(__package__)
+
+__all__ = [
+    'format_welcome_message',
+    'Welcome',
+]
+
+def format_welcome_message(welcome_message, ctx):
+    user = ctx.author
+    channel = ctx.channel
+    guild = ctx.guild
+
+    return welcome_message.format(
+        mention=user.mention,
+        user=user.name,
+        discrim=user.discriminator,
+        userdiscrim=user_discrim(user),
+        user_id=user.id,
+        channel=channel.mention,
+        channel_name=channel.name,
+        channel_id=channel.id,
+        server=guild.name,
+        server_id=guild.id,
+        guild=guild.name,
+        guild_id=guild.id,
+    )
+
+class Welcome:
+    __slots__ = (
+        'bot',
+        'recently_joined',
+    )
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.recently_joined = deque(maxlen=5)
+
+    async def member_join(self, member):
+        logger.info("Member %s (%d) joined '%s' (%d)",
+                user_discrim(member), member.id, member.guild.name, member.guild.id)
+
+        welcome = self.bot.sql.welcome.get_welcome(member.guild)
+        roles = self.bot.sql.settings.get_special_roles(member.guild)
+
+        if welcome.welcome_message and welcome.channel:
+            ctx = FakeContext(author=member, channel=welcome.channel, guild=member.guild)
+            content = format_welcome_message(welcome.welcome_message, ctx)
+            await welcome.channel.send(content=content)
+
+        if roles.guest:
+            logger.info("Adding role %s (%d) to new guest", roles.guest.name, roles.guest.id)
+            await member.add_roles(roles.guest, reason="New user joined")
+
+    async def member_leave(self, member):
+        logger.info("Member %s (%d) left '%s' (%d)",
+                user_discrim(member), member.id, member.guild.name, member.guild.id)
+
+        welcome = self.bot.sql.welcome.get_welcome(member.guild)
+
+        if welcome.goodbye_message and welcome.channel:
+            ctx = FakeContext(author=member, channel=welcome.channel, guild=member.guild)
+            content = format_welcome_message(welcome.goodbye_message, ctx)
+            await welcome.channel.send(content=content)
+
+    @commands.command(name='agree', aliases=['accept'])
+    @commands.guild_only()
+    async def agree(self, ctx):
+        '''
+        Designate that you have agreed to the rules and other server information.
+        Required to be able to access the server.
+        '''
+
+        logger.debug("Unchecked !agree command received")
+
+        welcome = self.bot.sql.get_welcome(ctx.guild)
+        roles = self.bot.sql.settings.get_special_roles(ctx.guild)
+
+        if ctx.channel != welcome.channel:
+            # Not the welcome channel, ignore
+            raise InvalidCommandContext()
+
+        if ctx.author.permissions_in(ctx.channel).manage_messages:
+            # Not a guest, ignore
+            raise InvalidCommandContext()
+
+        if ctx.author in self.recently_joined:
+            # Already joining, ignore
+            raise InvalidCommandContext()
+
+        logger.info("Guest %s (%d) just agreed to the rules and policies!",
+                ctx.author.name, ctx.author.id)
+
+        self.recently_joined.append(ctx.author)
+
+        if roles.member:
+            logger.info("Adding member role %s (%d)", roles.member.name, roles.member.id)
+            await ctx.author.add_roles(roles.member, reason='Agreed to the rules and policies')
+
+        if roles.guest:
+            logger.info("Removing guest role %s (%d)", roles.guest.name, roles.guest.id)
+            await ctx.author.remove_roles(roles.guest, reason='Agreed to the rules and policies')
+
+        if welcome.agreed_message:
+            await ctx.send(content=format_welcome_message(welcome.agreed_message, ctx))
+
+        # TODO: restore old roles
+
+        if welcome.delete_on_agree:
+            await ctx.message.delete()
+
+            # Prevent the bot from attempting to add a success reaction
+            raise InvalidCommandContext()

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -159,10 +159,12 @@ class Welcome:
     async def welcome(self, ctx):
         ''' Manages the welcome cog for managing new users and roles. '''
 
+        print('>>', ctx.command, ctx.invoked_with, ctx.kwargs)
+        print('$$', ctx.invoked_subcommand)
         if ctx.invoked_subcommand is None:
             raise SendHelp(ctx.command)
 
-    @welcome.command(name='getchannel', alias=['getch'])
+    @welcome.command(name='getchan')
     @commands.guild_only()
     async def get_welcome_channel(self, ctx):
         ''' Gets the welcome channel. '''
@@ -180,7 +182,7 @@ class Welcome:
             Reactions.SUCCESS.add(ctx.message),
         )
 
-    @welcome.command(name='setchannel', alias=['setch'])
+    @welcome.command(name='setchan')
     @commands.guild_only()
     @permissions.check_admin()
     async def set_welcome_channel(self, ctx, channel: discord.TextChannel):
@@ -196,7 +198,7 @@ class Welcome:
         self.journal.send('channel/set', ctx.guild, content, icon='settings',
                 channel=channel, cause=ctx.author)
 
-    @welcome.command(name='unsetchannel', alias=['unsetch', 'noch'])
+    @welcome.command(name='unsetchan')
     @commands.guild_only()
     @permissions.check_admin()
     async def unset_welcome_channel(self, ctx):

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -162,7 +162,7 @@ class Welcome:
         if ctx.invoked_subcommand is None:
             raise SendHelp(ctx.command)
 
-    @welcome.command(name='welcomechannel', alias=['wchannel', 'getch'])
+    @welcome.command(name='getchannel', alias=['getch'])
     @commands.guild_only()
     async def get_welcome_channel(self, ctx):
         ''' Gets the welcome channel. '''
@@ -180,7 +180,7 @@ class Welcome:
             Reactions.SUCCESS.add(ctx.message),
         )
 
-    @welcome.command(name='setwelcomechannel', alias=['swchannel', 'setch'])
+    @welcome.command(name='setchannel', alias=['setch'])
     @commands.guild_only()
     @permissions.check_admin()
     async def set_welcome_channel(self, ctx, channel: discord.TextChannel):
@@ -196,7 +196,7 @@ class Welcome:
         self.journal.send('channel/set', ctx.guild, content, icon='settings',
                 channel=channel, cause=ctx.author)
 
-    @welcome.command(name='nowelcomechannel', alias=['nwchannel', 'unsetch'])
+    @welcome.command(name='unsetchannel', alias=['unsetch', 'noch'])
     @commands.guild_only()
     @permissions.check_admin()
     async def unset_welcome_channel(self, ctx):

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -158,6 +158,12 @@ class Welcome:
         if welcome.goodbye_message and welcome.channel:
             await self.send_welcome_message(member, welcome.goodbye_message, welcome.channel)
 
+        # Remove from recently_joined, they need to re-agree!
+        try:
+            self.recently_joined.remove(member)
+        except ValueError:
+            pass
+
     @commands.command(name='agree', aliases=['accept'], hidden=True)
     @commands.guild_only()
     async def agree(self, ctx):
@@ -168,7 +174,7 @@ class Welcome:
 
         logger.debug("Unchecked !agree command received")
 
-        welcome = self.bot.sql.get_welcome(ctx.guild)
+        welcome = self.bot.sql.welcome.get_welcome(ctx.guild)
         roles = self.bot.sql.settings.get_special_roles(ctx.guild)
 
         if ctx.channel != welcome.channel:

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -159,8 +159,6 @@ class Welcome:
     async def welcome(self, ctx):
         ''' Manages the welcome cog for managing new users and roles. '''
 
-        print('>>', ctx.command, ctx.invoked_with, ctx.kwargs)
-        print('$$', ctx.invoked_subcommand)
         if ctx.invoked_subcommand is None:
             raise SendHelp(ctx.command)
 
@@ -198,6 +196,8 @@ class Welcome:
         self.journal.send('channel/set', ctx.guild, content, icon='settings',
                 channel=channel, cause=ctx.author)
 
+        await Reactions.SUCCESS.add(ctx.message)
+
     @welcome.command(name='unsetchan')
     @commands.guild_only()
     @permissions.check_admin()
@@ -213,3 +213,5 @@ class Welcome:
         content = f'{user_discrim(ctx.author)} unset the welcome channel'
         self.journal.send('channel/set', ctx.guild, content, icon='settings',
                 channel=None, cause=ctx.author)
+
+        await Reactions.SUCCESS.add(ctx.message)

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -18,9 +18,10 @@ from collections import namedtuple
 
 import toml
 
+from futaba.exceptions import InvalidConfigError
+
 __all__ = [
     'Configuration',
-    'InvalidConfigError',
     'load_config',
 ]
 
@@ -35,11 +36,6 @@ Configuration = namedtuple(
         'database_url',
     ),
 )
-
-class InvalidConfigError(RuntimeError):
-    def __init__(self, message, config):
-        super().__init__(message)
-        self.config = config
 
 def _get(config, field, path=None):
     if field not in config:

--- a/futaba/emojis.py
+++ b/futaba/emojis.py
@@ -1,0 +1,123 @@
+#
+# emojis.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Module for managing the bot's emoji usage.
+'''
+
+__all__ = [
+    'ICONS',
+]
+
+ICONS = {
+    # Logging levels
+    'info': '\N{INFORMATION SOURCE}',
+    'idea': '\N{ELECTRIC LIGHT BULB}',
+    'warning': '\N{WARNING SIGN}',
+    'error': '\N{CROSS MARK}',
+    'forbidden': '\N{NO ENTRY}',
+    'critical': '\N{SQUARED SOS}',
+    'ok': '\N{SQUARED OK}',
+    'announce': '\N{CHEERING MEGAPHONE}',
+
+    # Moderation
+    'ban': '\N{HAMMER}',
+    'unban': '\N{FACE WITH HEAD-BANDAGE}',
+    'soft': '\N{BED}',
+    'kick': '\N{WOMANS BOOTS}',
+    'muffled': '\N{FACE WITH MEDICAL MASK}',
+    'mute': '\N{ZIPPER-MOUTH FACE}',
+    'jail': '\N{POLICE OFFICER}',
+    'shutdown': '\N{SKULL}',
+
+    # Roles
+    'member': '\N{MAN}',
+    'guest': '\N{EXTRATERRESTRIAL ALIEN}',
+
+    # Filter
+    'filter': '\N{PAGE WITH CURL}',
+    'flag': '\N{TRIANGULAR FLAG ON POST}',
+    'deleted': '\N{SKULL}',
+    'nsfw': '\N{NO ONE UNDER EIGHTEEN SYMBOL}',
+
+    # Mail
+    'has-mail': '\N{OPEN MAILBOX WITH RAISED FLAG}',
+    'no-mail': '\N{CLOSED MAILBOX WITH LOWERED FLAG}',
+
+    # Tracking
+    'typing': '\N{WRITING HAND}',
+    'message': '\N{PAGE FACING UP}',
+    'delete': '\N{WASTEBASKET}',
+    'item_add': '\N{HEAVY PLUS SIGN}',
+    'item_remove': '\N{HEAVY MINUS SIGN}',
+    'item_clear': '\N{HEAVY MULTIPLICATION X}',
+    'channel': '#\N{COMBINING ENCLOSING KEYCAP}',
+    'join': '\N{INBOX TRAY}',
+    'leave': '\N{OUTBOX TRAY}',
+
+    # Watchdog
+    'investigate': '\N{SLEUTH OR SPY}',
+    'found': '\N{EYE}',
+
+    # Configuration
+    'edit': '\N{MEMO}',
+    'save': '\N{FLOPPY DISK}',
+    'writing': '\N{WRITING HAND}',
+    'settings': '\N{HAMMER AND WRENCH}',
+
+    # Development
+    'deploy': '\N{ROCKET}',
+    'package': '\N{PACKAGE}',
+    'script': '\N{SCROLL}',
+
+    # Security
+    'key': '\N{KEY}',
+    'lock': '\N{LOCK}',
+    'unlock': '\N{OPEN LOCK}',
+
+    # Documents
+    'folder': '\N{OPEN FILE FOLDER}',
+    'file': '\N{PAGE FACING UP}',
+    'book': '\N{NOTEBOOK WITH DECORATIVE COVER}',
+    'upload': '\N{OUTBOX TRAY}',
+    'download': '\N{INBOX TRAY}',
+    'bookmark': '\N{BOOKMARK}',
+    'journal': '\N{LEDGER}',
+    'attachment': '\N{PAPERCLIP}',
+    'clipboard': '\N{CLIPBOARD}',
+    'pin': '\N{PUSHPIN}',
+    'briefcase': '\N{BRIEFCASE}',
+    'cabinet': '\N{CARD FILE BOX}',
+    'trash': '\N{WASTEBASKET}',
+
+    # Miscellaneous
+    'next': '\N{DOWNWARDS BLACK ARROW}',
+    'previous': '\N{UPWARDS BLACK ARROW}',
+    'hourglass': '\N{HOURGLASS WITH FLOWING SAND}',
+    'person': '\N{BUST IN SILHOUETTE}',
+    'navigate': '\N{COMPASS}',
+    'bot': '\N{ROBOT FACE}',
+    'news': '\N{NEWSPAPER}',
+    'art': '\N{ARTIST PALETTE}',
+    'tag': '\N{TICKET}',
+    'music': '\N{MUSICAL NOTE}',
+    'link': '\N{LINK SYMBOL}',
+    'alert': '\N{BELL}',
+    'game': '\N{VIDEO GAME}',
+    'search': '\N{LEFT-POINTING MAGNIFYING GLASS}',
+    'bomb': '\N{BOMB}',
+    'gift': '\N{WRAPPED PRESENT}',
+    'celebration': '\N{PARTY POPPER}',
+    'international': '\N{GLOBE WITH MERIDIANS}',
+    'award': '\N{TROPHY}',
+    'luck': '\N{FOUR LEAF CLOVER}',
+}

--- a/futaba/emojis.py
+++ b/futaba/emojis.py
@@ -39,7 +39,9 @@ ICONS = {
     'jail': '\N{POLICE OFFICER}',
     'shutdown': '\N{SKULL}',
 
-    # Roles
+
+    # Welcome / Roles
+    'agree': '\N{THUMBS UP SIGN}',
     'member': '\N{MAN}',
     'guest': '\N{EXTRATERRESTRIAL ALIEN}',
 

--- a/futaba/enums.py
+++ b/futaba/enums.py
@@ -16,6 +16,7 @@ import discord
 
 __all__ = [
     'Reactions',
+    'MemberLeaveType',
     'FilterType',
     'LocationType',
 ]
@@ -29,6 +30,13 @@ class Reactions(Enum):
 
     async def add(self, message: discord.Message):
         await message.add_reaction(self.value)
+
+@unique
+class MemberLeaveType(Enum):
+    LEFT = 'member_left'
+    PRUNED = 'pruned'
+    KICKED = 'kicked'
+    BANNED = 'banned'
 
 @unique
 class FilterType(Enum):

--- a/futaba/exceptions.py
+++ b/futaba/exceptions.py
@@ -12,14 +12,27 @@
 
 __all__ = [
     'CommandFailed',
+    'SendHelp',
     'InvalidCommandContext',
     'InvalidConfigError',
 ]
 
 class CommandFailed(RuntimeError):
-    def __init__(self, **send_kwargs):
+    def __init__(self, content=None, embed=None, file=None):
         super().__init__()
-        self.send_kwargs = send_kwargs
+        self.kwargs = {}
+
+        if content is not None:
+            self.kwargs['content'] = content
+        if embed is not None:
+            self.kwargs['embed'] = embed
+        if file is not None:
+            self.kwargs['file'] = file
+
+class SendHelp(RuntimeError):
+    def __init__(self, command):
+        super().__init__()
+        self.command = command
 
 class InvalidCommandContext(RuntimeError):
     pass

--- a/futaba/exceptions.py
+++ b/futaba/exceptions.py
@@ -1,0 +1,30 @@
+#
+# exceptions.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+__all__ = [
+    'CommandFailed',
+    'InvalidCommandContext',
+    'InvalidConfigError',
+]
+
+class CommandFailed(RuntimeError):
+    def __init__(self, **send_kwargs):
+        super().__init__()
+        self.send_kwargs = send_kwargs
+
+class InvalidCommandContext(RuntimeError):
+    pass
+
+class InvalidConfigError(RuntimeError):
+    def __init__(self, message, config):
+        super().__init__(message)
+        self.config = config

--- a/futaba/journal/__init__.py
+++ b/futaba/journal/__init__.py
@@ -17,6 +17,6 @@ Broadcaster and Listener classes that rely on it.
 '''
 
 from .broadcaster import Broadcaster
-from .impl import ChannelOutputListener, LoggingOutputListener
+from .impl import ChannelOutputListener, LoggingOutputListener, ModerationListener
 from .listener import Listener
 from .router import Router

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -37,5 +37,5 @@ class Broadcaster:
         path = self.path.joinpath(subpath)
 
         # Queue up event
-        logger.info("Sending journal entry to %s: '%s' %s", path, content, attributes)
+        logger.debug("Sending journal entry to %s: '%s'", path, content)
         self.router.queue.put_nowait((path, guild, content, attributes))

--- a/futaba/journal/impl/__init__.py
+++ b/futaba/journal/impl/__init__.py
@@ -16,3 +16,4 @@ Module for implementations of Listeners or other subclasses.
 
 from .channel_output import ChannelOutputListener
 from .logging_output import LoggingOutputListener
+from .moderation import ModerationListener

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -49,5 +49,5 @@ class ChannelOutputListener(Listener):
         Send the message to the given channel, applying the icon if applicable.
         '''
 
-        logger.info("Received journal event on %s: '%s'", path, content)
+        logger.debug("Received journal event on %s: '%s'", path, content)
         await self.channel.send(content=content)

--- a/futaba/journal/impl/moderation.py
+++ b/futaba/journal/impl/moderation.py
@@ -1,0 +1,72 @@
+#
+# journal/impl/moderation.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+A Listener for use by the moderation cog to properly output journal events for
+kicks and ban events.
+'''
+
+import logging
+
+from ..listener import Listener
+
+from futaba.enums import MemberLeaveType
+from futaba.utils import user_discrim
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'ModerationListener',
+]
+
+# TODO fix doubling up of moderation journal events being sent
+
+class ModerationListener(Listener):
+    def __init__(self, router, bot):
+        super().__init__(router, '/member/leave', recursive=False)
+        self.broadcaster = bot.get_broadcaster('/moderation')
+
+    async def handle(self, j_path, guild, j_content, attributes):
+        '''
+        Handle the incoming leave event, and output a kick or ban journal event as appropriate.
+        '''
+
+        leaver = attributes['member']
+        cause = attributes['cause']
+
+        logger.debug("Received member leave event: %s (%d)", leaver.name, leaver.id)
+
+        if cause.type == MemberLeaveType.KICKED:
+            action = 'kicked'
+            path = 'member/kick'
+            icon = 'kick'
+        elif cause.type == MemberLeaveType.BANNED:
+            action = 'banned'
+            path = 'member/ban'
+            icon = 'ban'
+        else:
+            # We don't care about this event!
+            return
+
+        # Get formatted reason
+        if cause.reason:
+            reason = f'with reason: `{escape_backticks(cause.reason)}`'
+        else:
+            reason = ''
+
+        # Build journal event content
+        mod = user_discrim(cause.cause)
+        leaver_discrim = user_discrim(leaver)
+
+        logger.info("Sending journal event %s for %s (%d)", path, leaver.name, leaver.id)
+        content = f'{mod} {action} {leaver.mention} ({leaver_discrim}) {reason}'
+        self.broadcaster.send(path, guild, content, icon=icon)

--- a/futaba/journal/impl/moderation.py
+++ b/futaba/journal/impl/moderation.py
@@ -17,10 +17,10 @@ kicks and ban events.
 
 import logging
 
-from ..listener import Listener
-
 from futaba.enums import MemberLeaveType
-from futaba.utils import user_discrim
+from futaba.utils import escape_backticks, user_discrim
+
+from ..listener import Listener
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +35,13 @@ class ModerationListener(Listener):
         super().__init__(router, '/member/leave', recursive=False)
         self.broadcaster = bot.get_broadcaster('/moderation')
 
-    async def handle(self, j_path, guild, j_content, attributes):
+    async def handle(self, _path, guild, _content, attributes):
         '''
         Handle the incoming leave event, and output a kick or ban journal event as appropriate.
         '''
+
+        # We want to ignore two arguments
+        # pylint: disable=arguments-differ
 
         leaver = attributes['member']
         cause = attributes['cause']

--- a/futaba/journal/process.py
+++ b/futaba/journal/process.py
@@ -14,110 +14,11 @@
 Middleware for handling events before they are sent to all the listeners.
 '''
 
+from futaba.emojis import ICONS
+
 __all__ = [
-    'ICONS',
     'process_content',
 ]
-
-ICONS = {
-    # Logging levels
-    'info': '\N{INFORMATION SOURCE}',
-    'idea': '\N{ELECTRIC LIGHT BULB}',
-    'warning': '\N{WARNING SIGN}',
-    'error': '\N{CROSS MARK}',
-    'forbidden': '\N{NO ENTRY}',
-    'critical': '\N{SQUARED SOS}',
-    'ok': '\N{SQUARED OK}',
-    'announce': '\N{CHEERING MEGAPHONE}',
-
-    # Moderation
-    'ban': '\N{HAMMER}',
-    'unban': '\N{FACE WITH HEAD-BANDAGE}',
-    'soft': '\N{BED}',
-    'kick': '\N{WOMANS BOOTS}',
-    'muffled': '\N{FACE WITH MEDICAL MASK}',
-    'mute': '\N{SPEAK-NO-EVIL MONKEY}',
-    'jail': '\N{POLICE CARS REVOLVING LIGHT}',
-    'shutdown': '\N{SKULL}',
-
-    # Filter
-    'filter': '\N{PAGE WITH CURL}',
-    'flag': '\N{TRIANGULAR FLAG ON POST}',
-    'deleted': '\N{SKULL}',
-    'nsfw': '\N{NO ONE UNDER EIGHTEEN SYMBOL}',
-
-    # Mail
-    'has-mail': '\N{OPEN MAILBOX WITH RAISED FLAG}',
-    'no-mail': '\N{CLOSED MAILBOX WITH LOWERED FLAG}',
-
-    # Tracking
-    'typing': '\N{WRITING HAND}',
-    'message': '\N{PAGE FACING UP}',
-    'delete': '\N{WASTEBASKET}',
-    'item_add': '\N{HEAVY PLUS SIGN}',
-    'item_remove': '\N{HEAVY MINUS SIGN}',
-    'item_clear': '\N{HEAVY MULTIPLICATION X}',
-    'channel': '#\N{COMBINING ENCLOSING KEYCAP}',
-    'join': '\N{INBOX TRAY}',
-    'leave': '\N{OUTBOX TRAY}',
-
-    # Watchdog
-    'investigate': '\N{SLEUTH OR SPY}',
-    'found': '\N{EYE}',
-
-    # Configuration
-    'edit': '\N{MEMO}',
-    'save': '\N{FLOPPY DISK}',
-    'writing': '\N{WRITING HAND}',
-    'settings': '\N{HAMMER AND WRENCH}',
-
-    # Development
-    'deploy': '\N{ROCKET}',
-    'package': '\N{PACKAGE}',
-    'script': '\N{SCROLL}',
-
-    # Security
-    'key': '\N{KEY}',
-    'lock': '\N{LOCK}',
-    'unlock': '\N{OPEN LOCK}',
-
-    # Documents
-    'folder': '\N{OPEN FILE FOLDER}',
-    'file': '\N{PAGE FACING UP}',
-    'book': '\N{NOTEBOOK WITH DECORATIVE COVER}',
-    'upload': '\N{OUTBOX TRAY}',
-    'download': '\N{INBOX TRAY}',
-    'bookmark': '\N{BOOKMARK}',
-    'journal': '\N{LEDGER}',
-    'attachment': '\N{PAPERCLIP}',
-    'clipboard': '\N{CLIPBOARD}',
-    'pin': '\N{PUSHPIN}',
-    'briefcase': '\N{BRIEFCASE}',
-    'cabinet': '\N{CARD FILE BOX}',
-    'trash': '\N{WASTEBASKET}',
-
-    # Miscellaneous
-    'next': '\N{DOWNWARDS BLACK ARROW}',
-    'previous': '\N{UPWARDS BLACK ARROW}',
-    'hourglass': '\N{HOURGLASS WITH FLOWING SAND}',
-    'person': '\N{BUST IN SILHOUETTE}',
-    'navigate': '\N{COMPASS}',
-    'bot': '\N{ROBOT FACE}',
-    'news': '\N{NEWSPAPER}',
-    'art': '\N{ARTIST PALETTE}',
-    'tag': '\N{TICKET}',
-    'music': '\N{MUSICAL NOTE}',
-    'link': '\N{LINK SYMBOL}',
-    'alert': '\N{BELL}',
-    'game': '\N{VIDEO GAME}',
-    'search': '\N{LEFT-POINTING MAGNIFYING GLASS}',
-    'bomb': '\N{BOMB}',
-    'gift': '\N{WRAPPED PRESENT}',
-    'celebration': '\N{PARTY POPPER}',
-    'international': '\N{GLOBE WITH MERIDIANS}',
-    'award': '\N{TROPHY}',
-    'luck': '\N{FOUR LEAF CLOVER}',
-}
 
 def process_content(content, attributes):
     ''' Modifies the content based on the passed attributes. '''

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -61,7 +61,7 @@ class Router:
         while True:
             logger.debug("Waiting for new journal event")
             event_path, guild, content, attributes = await self.queue.get()
-            logger.info("Got journal event on %s: '%s' %s", event_path, content, attributes)
+            logger.debug("Got journal event on %s: '%s'", event_path, content)
             content = process_content(content, attributes)
             logger.debug("Journal content after processing: '%s'", content)
 

--- a/futaba/permissions.py
+++ b/futaba/permissions.py
@@ -18,32 +18,29 @@ import discord
 from discord.ext import commands
 
 __all__ = [
+    'owner_perm',
+    'admin_perm',
+    'mod_perm',
     'check_owner',
     'check_admin',
     'check_mod',
 ]
 
-def check_owner_perm(ctx: commands.Context):
-    '''
-    Check if user is a owner of the bot from config
-    '''
+def owner_perm(ctx: commands.Context):
+    ''' Check if user is a owner of the bot from config '''
 
     return ctx.author.id in ctx.bot.config.owner_ids
 
-def check_admin_perm(ctx: commands.Context):
-    '''
-    Used to check is user has the manage_guild permission
-    '''
+def admin_perm(ctx: commands.Context):
+    ''' Used to check is user has the manage_guild permission '''
 
     if isinstance(ctx.channel, discord.abc.PrivateChannel):
         return False
 
     return ctx.channel.permissions_for(ctx.author).manage_guild
 
-def check_mod_perm(ctx: commands.Context):
-    '''
-    Used to check is user has the manage_channels permission
-    '''
+def mod_perm(ctx: commands.Context):
+    ''' Used to check is user has the manage_channels permission '''
 
     if isinstance(ctx.channel, discord.abc.PrivateChannel):
         return False
@@ -51,30 +48,24 @@ def check_mod_perm(ctx: commands.Context):
     return ctx.channel.permissions_for(ctx.author).manage_channels
 
 def check_owner():
-    '''
-    Check if user is a owner
-    '''
+    ''' Check if user is a owner '''
 
-    return commands.check(check_owner_perm)
+    return commands.check(owner_perm)
 
 def check_admin():
-    '''
-    Check if user is admin or higher
-    '''
+    ''' Check if user is admin or higher '''
 
     def checkperm(ctx):
         ''' Check the different perms '''
-        return check_owner_perm(ctx) or check_admin_perm(ctx)
+        return owner_perm(ctx) or admin_perm(ctx)
 
     return commands.check(checkperm)
 
 def check_mod():
-    '''
-    Check if user is moderator or higher
-    '''
+    ''' Check if user is moderator or higher '''
 
     def checkperm(ctx):
         ''' Check the different perms '''
-        return check_owner_perm(ctx) or check_admin_perm(ctx) or check_mod_perm(ctx)
+        return owner_perm(ctx) or admin_perm(ctx) or mod_perm(ctx)
 
     return commands.check(checkperm)

--- a/futaba/sql/handle.py
+++ b/futaba/sql/handle.py
@@ -18,7 +18,7 @@ import logging
 
 from sqlalchemy import create_engine, MetaData
 
-from .models import FilterModel, GuildsModel, JournalModel, SettingsModel
+from .models import FilterModel, GuildsModel, JournalModel, SettingsModel, WelcomeModel
 from .transaction import Transaction
 
 logger = logging.getLogger(__name__)
@@ -37,6 +37,7 @@ class SqlHandler:
         'guilds',
         'journal',
         'settings',
+        'welcome',
     )
 
     def __init__(self, db_path: str):
@@ -50,6 +51,7 @@ class SqlHandler:
         self.guilds = GuildsModel(self, meta)
         self.journal = JournalModel(self, meta)
         self.settings = SettingsModel(self, meta)
+        self.welcome = WelcomeModel(self, meta)
 
         meta.create_all(self.db)
         logger.info("Created all tables.")

--- a/futaba/sql/hooks.py
+++ b/futaba/sql/hooks.py
@@ -34,7 +34,7 @@ def register_hook(name, hook):
     if name not in HOOK_NAMES:
         raise ValueError(f"No such hook type: {name}")
 
-    logger.info("Register hook %s for '%s'", hook.__name__, name)
+    logger.info("Registered hook %s for '%s'", hook.__name__, name)
     hooks[name].append(hook)
 
 def run_hooks(name, *args, **kwargs):

--- a/futaba/sql/hooks.py
+++ b/futaba/sql/hooks.py
@@ -34,7 +34,7 @@ def register_hook(name, hook):
     if name not in HOOK_NAMES:
         raise ValueError(f"No such hook type: {name}")
 
-    logger.info("Register hook %r for '%s'", hook, name)
+    logger.info("Register hook %s for '%s'", hook.__name__, name)
     hooks[name].append(hook)
 
 def run_hooks(name, *args, **kwargs):

--- a/futaba/sql/models/__init__.py
+++ b/futaba/sql/models/__init__.py
@@ -15,17 +15,8 @@ Module that contains models for interacting with SQL tables in a clean
 and abstracted way.
 '''
 
-import os
-import sys
-
 from .filter import FilterModel
 from .guilds import GuildsModel
 from .journal import JournalModel
 from .settings import SettingsModel
-
-__all__ = [
-    'FilterModel',
-    'GuildsModel',
-    'JournalModel',
-    'SettingsModel',
-]
+from .welcome import WelcomeModel

--- a/futaba/sql/models/filter.py
+++ b/futaba/sql/models/filter.py
@@ -300,6 +300,11 @@ class FilterModel:
                 ]) \
                 .where(self.tb_filter_settings.c.guild_id == guild.id)
         result = self.sql.execute(sel)
+
+        if not result.rowcount:
+            self.add_settings(guild)
+            return self.settings_cache[guild]
+
         bot_immune, manage_messages_immune, reupload = result.fetchone()
 
         # Update cache

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -72,6 +72,12 @@ class SpecialRoleStorage:
 
         return discord.utils.get(self.guild.roles, id=id)
 
+    def __iter__(self):
+        yield self.member_role
+        yield self.guest_role
+        yield self.mute_role
+        yield self.jail_role
+
 class SettingsModel:
     __slots__ = (
         'sql',
@@ -229,7 +235,7 @@ class SettingsModel:
         values = {}
         for attr, role in attrs.items():
             assert attr in ('member_role', 'guest_role', 'mute_role', 'jail_role'), "Unknown column"
-            values[attr] = role.id
+            values[attr] = getattr(role, 'id', None)
 
         upd = self.tb_special_roles \
                 .update() \

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -234,8 +234,8 @@ class SettingsModel:
 
         values = {}
         for attr, role in attrs.items():
-            assert attr in ('member_role', 'guest_role', 'mute_role', 'jail_role'), "Unknown column"
-            values[attr] = getattr(role, 'id', None)
+            assert attr in ('member', 'guest', 'mute', 'jail'), "Unknown column"
+            values[f'{attr}_role_id'] = getattr(role, 'id', None)
 
         upd = self.tb_special_roles \
                 .update() \

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -21,7 +21,11 @@ import functools
 import logging
 
 import discord
+<<<<<<< HEAD
 from sqlalchemy import BigInteger, Column, Table, Unicode
+=======
+from sqlalchemy import BigInteger, Boolean, Column, Table, Unicode
+>>>>>>> Add special roles table.
 from sqlalchemy import CheckConstraint, ForeignKey, UniqueConstraint
 from sqlalchemy.sql import select
 
@@ -50,6 +54,7 @@ class SpecialRoleStorage:
         self.mute_role = self._get_role(mute_role_id)
         self.jail_role = self._get_role(jail_role_id)
 
+<<<<<<< HEAD
     def update(self, attrs):
         logger.debug("Updating special role storage: %s", attrs)
         if 'member' in attrs:
@@ -77,18 +82,23 @@ class SpecialRoleStorage:
     def jail(self):
         return self.jail_role
 
+=======
+>>>>>>> Add special roles table.
     def _get_role(self, id):
         if id is None:
             return None
 
         return discord.utils.get(self.guild.roles, id=id)
 
+<<<<<<< HEAD
     def __iter__(self):
         yield self.member_role
         yield self.guest_role
         yield self.mute_role
         yield self.jail_role
 
+=======
+>>>>>>> Add special roles table.
 class SettingsModel:
     __slots__ = (
         'sql',

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -20,8 +20,9 @@ Has the model for managing persistent bot settings.
 import functools
 import logging
 
+import discord
 from sqlalchemy import BigInteger, Boolean, Column, Table, Unicode
-from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy import CheckConstraint, ForeignKey, UniqueConstraint
 from sqlalchemy.sql import select
 
 from ..hooks import register_hook
@@ -33,11 +34,35 @@ __all__ = [
     'SettingsModel',
 ]
 
+class SpecialRoleStorage:
+    __slots__ = (
+        'guild',
+        'member_role',
+        'guest_role',
+        'mute_role',
+        'jail_role',
+    )
+
+    def __init__(self, guild, member_role_id, guest_role_id, mute_role_id, jail_role_id):
+        self.guild = guild
+        self.member_role = self._get_role(member_role_id)
+        self.guest_role = self._get_role(guest_role_id)
+        self.mute_role = self._get_role(mute_role_id)
+        self.jail_role = self._get_role(jail_role_id)
+
+    def _get_role(self, id):
+        if id is None:
+            return None
+
+        return discord.utils.get(self.guild.roles, id=id)
+
 class SettingsModel:
     __slots__ = (
         'sql',
         'tb_prefixes',
+        'tb_special_roles',
         'prefix_cache',
+        'roles_cache',
     )
 
     def __init__(self, sql, meta):
@@ -45,10 +70,43 @@ class SettingsModel:
         self.tb_prefixes = Table('prefixes', meta,
                 Column('guild_id', BigInteger, ForeignKey('guilds.guild_id'), primary_key=True),
                 Column('prefix', Unicode, nullable=True))
+        self.tb_special_roles = Table('special_roles', meta,
+                Column('guild_id', BigInteger, ForeignKey('guilds.guild_id'), primary_key=True),
+                Column('member_role_id', BigInteger, nullable=True),
+                Column('guest_role_id', BigInteger, nullable=True),
+                Column('mute_role_id', BigInteger, nullable=True),
+                Column('jail_role_id', BigInteger, nullable=True),
+                # Ensures special roles aren't assigned to @everyone
+                CheckConstraint(
+                    'member_role_id is NULL OR member_role_id != guild_id',
+                    name='special_role_member_not_everyone_check'),
+                CheckConstraint(
+                    'guest_role_id is NULL or guest_role_id != guild_id',
+                    name='special_role_guest_not_everyone_check'),
+                CheckConstraint(
+                    'mute_role_id is NULL or mute_role_id != guild_id',
+                    name='special_role_mute_not_everyone_check'),
+                CheckConstraint(
+                    'jail_role_id is NULL or jail_role_id != guild_id',
+                    name='special_role_jail_not_everyone_check'),
+                # Ensures Guest and punishment roles aren't the same as the Member role
+                CheckConstraint(
+                    'guest_role_id is NULL OR guest_role_id != member_role_id',
+                    name='special_role_guest_not_member_check'),
+                CheckConstraint(
+                    'mute_role_id is NULL OR mute_role_id != member_role_id',
+                    name='special_role_mute_not_member_check'),
+                CheckConstraint(
+                    'jail_role_id is NULL OR jail_role_id != member_role_id',
+                    name='special_role_jail_not_member_check'))
         self.prefix_cache = {}
+        self.roles_cache = {}
 
         register_hook('on_guild_join', self.add_prefix)
         register_hook('on_guild_leave', self.del_prefix)
+
+        register_hook('on_guild_join', self.add_special_roles)
+        register_hook('on_guild_leave', self.del_special_roles)
 
     def add_prefix(self, guild):
         logger.info("Adding prefix row for new guild '%s' (%d)", guild.name, guild.id)
@@ -95,3 +153,71 @@ class SettingsModel:
                 .values(prefix=prefix)
         self.sql.execute(upd)
         self.prefix_cache[guild] = prefix
+
+    def add_special_roles(self, guild):
+        logger.info("Adding special roles row for new guild '%s' (%d)", guild.name, guild.id)
+        ins = self.tb_special_roles \
+                .insert() \
+                .values(
+                    guild_id=guild.id,
+                    member_role_id=None,
+                    guest_role_id=None,
+                    mute_role_id=None,
+                    jail_role_id=None,
+                )
+        self.sql.execute(ins)
+        self.roles_cache[guild] = SpecialRoleStorage(guild, None, None, None, None)
+
+    def del_special_roles(self, guild):
+        logger.info("Removing special roles row for new guild '%s' (%d)", guild.name, guild.id)
+        delet = self.tb_special_roles \
+                    .delete() \
+                    .where(self.tb_special_roles.c.guild_id == guild.id)
+        self.sql.execute(delet)
+        self.roles_cache.pop(guild, None)
+
+    def get_special_roles(self, guild):
+        logger.debug("Getting special roles for guild '%s' (%d)", guild.name, guild.id)
+        if guild in self.roles_cache:
+            logger.debug("Special roles found in cache, returning")
+            return self.roles_cache[guild]
+
+        sel = select([
+                    self.tb_special_roles.c.member_role_id,
+                    self.tb_special_roles.c.guest_role_id,
+                    self.tb_special_roles.c.mute_role_id,
+                    self.tb_special_roles.c.jail_role_id,
+                ]) \
+                .where(self.tb_special_roles.c.guild_id == guild.id)
+        result = self.sql.execute(sel)
+
+        if not result.rowcount:
+            self.add_special_roles(guild)
+            return self.roles_cache[guild]
+
+        member_role_id, guest_role_id, mute_role_id, jail_role_id = result.fetchone()
+        roles = SpecialRoleStorage(
+            guild,
+            member_role_id,
+            guest_role_id,
+            mute_role_id,
+            jail_role_id,
+        )
+        self.roles_cache[guild] = roles
+        return roles
+
+    def set_special_roles(self, guild, **attrs):
+        self.logger.info("Setting special role(s) for guild '%s' (%d)", guild.name, guild.id)
+        assert attrs, "No roles to change"
+
+        values = {}
+        for attr, role in attrs.items():
+            assert attr in ('member_role', 'guest_role', 'mute_role', 'jail_role'), "Unknown column"
+            values[attr] = role.id
+
+        upd = self.tb_special_roles \
+                .update() \
+                .where(self.tb_special_roles.c.guild_id == guild.id) \
+                .values(values)
+        self.sql.execute(upd)
+        self.roles_cache.update(attrs)

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -50,6 +50,22 @@ class SpecialRoleStorage:
         self.mute_role = self._get_role(mute_role_id)
         self.jail_role = self._get_role(jail_role_id)
 
+    @property
+    def member(self):
+        return self.member_role
+
+    @property
+    def guest(self):
+        return self.guest_role
+
+    @property
+    def mute(self):
+        return self.mute_role
+
+    @property
+    def jail(self):
+        return self.jail_role
+
     def _get_role(self, id):
         if id is None:
             return None

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -21,7 +21,7 @@ import functools
 import logging
 
 import discord
-from sqlalchemy import BigInteger, Boolean, Column, Table, Unicode
+from sqlalchemy import BigInteger, Column, Table, Unicode
 from sqlalchemy import CheckConstraint, ForeignKey, UniqueConstraint
 from sqlalchemy.sql import select
 
@@ -223,7 +223,7 @@ class SettingsModel:
         return roles
 
     def set_special_roles(self, guild, **attrs):
-        self.logger.info("Setting special role(s) for guild '%s' (%d)", guild.name, guild.id)
+        logger.info("Setting special role(s) for guild '%s' (%d)", guild.name, guild.id)
         assert attrs, "No roles to change"
 
         values = {}

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -189,7 +189,7 @@ class SettingsModel:
         return prefix
 
     def set_prefix(self, guild, prefix):
-        logger.info("Setting prefix to '%s' for guild '%s' (%d)", prefix, guild.name, guild.id)
+        logger.info("Setting prefix to %r for guild '%s' (%d)", prefix, guild.name, guild.id)
         upd = self.tb_prefixes \
                 .update() \
                 .where(self.tb_prefixes.c.guild_id == guild.id) \

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -21,11 +21,7 @@ import functools
 import logging
 
 import discord
-<<<<<<< HEAD
 from sqlalchemy import BigInteger, Column, Table, Unicode
-=======
-from sqlalchemy import BigInteger, Boolean, Column, Table, Unicode
->>>>>>> Add special roles table.
 from sqlalchemy import CheckConstraint, ForeignKey, UniqueConstraint
 from sqlalchemy.sql import select
 
@@ -54,7 +50,6 @@ class SpecialRoleStorage:
         self.mute_role = self._get_role(mute_role_id)
         self.jail_role = self._get_role(jail_role_id)
 
-<<<<<<< HEAD
     def update(self, attrs):
         logger.debug("Updating special role storage: %s", attrs)
         if 'member' in attrs:
@@ -82,23 +77,18 @@ class SpecialRoleStorage:
     def jail(self):
         return self.jail_role
 
-=======
->>>>>>> Add special roles table.
     def _get_role(self, id):
         if id is None:
             return None
 
         return discord.utils.get(self.guild.roles, id=id)
 
-<<<<<<< HEAD
     def __iter__(self):
         yield self.member_role
         yield self.guest_role
         yield self.mute_role
         yield self.jail_role
 
-=======
->>>>>>> Add special roles table.
 class SettingsModel:
     __slots__ = (
         'sql',

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -50,6 +50,17 @@ class SpecialRoleStorage:
         self.mute_role = self._get_role(mute_role_id)
         self.jail_role = self._get_role(jail_role_id)
 
+    def update(self, attrs):
+        logger.debug("Updating special role storage: %s", attrs)
+        if 'member' in attrs:
+            self.member_role = attrs['member']
+        if 'guest' in attrs:
+            self.guest_role = attrs['guest']
+        if 'mute' in attrs:
+            self.mute_role = attrs['mute']
+        if 'jail' in attrs:
+            self.jail_role = attrs['jail']
+
     @property
     def member(self):
         return self.member_role
@@ -242,4 +253,4 @@ class SettingsModel:
                 .where(self.tb_special_roles.c.guild_id == guild.id) \
                 .values(values)
         self.sql.execute(upd)
-        self.roles_cache.update(attrs)
+        self.roles_cache[guild].update(attrs)

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -60,7 +60,7 @@ class WelcomeStorage:
         self.goodbye_message = goodbye_message
         self.agreed_message = agreed_message
         self.delete_on_agree = delete_on_agree
-        self.welcome_channel = discord.utils.get(guild.roles, id=welcome_channel_id)
+        self.welcome_channel = discord.utils.get(guild.text_channels, id=welcome_channel_id)
 
     @property
     def channel(self):
@@ -127,6 +127,7 @@ class WelcomeModel:
         sel = select([
                     self.tb_welcome.c.welcome_message,
                     self.tb_welcome.c.goodbye_message,
+                    self.tb_welcome.c.agreed_message,
                     self.tb_welcome.c.delete_on_agree,
                     self.tb_welcome.c.welcome_channel_id,
                 ]) \
@@ -137,11 +138,19 @@ class WelcomeModel:
             self.add_welcome(guild)
             return self.cache[guild]
 
-        welcome_message, goodbye_message, delete_on_agree, welcome_channel_id = result.fetchone()
+        (
+            welcome_message,
+            goodbye_message,
+            agreed_message,
+            delete_on_agree,
+            welcome_channel_id,
+        ) = result.fetchone()
+
         welcome = WelcomeStorage(
             guild,
             welcome_message,
             goodbye_message,
+            agreed_message,
             delete_on_agree,
             welcome_channel_id,
         )

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -85,6 +85,7 @@ class WelcomeModel:
     def del_welcome(self, guild):
         logger.info("Removing welcome message row for guild '%s' (%d)", guild.name, guild.id)
         delet = self.tb_welcome \
+                .delete() \
                 .where(self.tb_welcome.c.guild_id == guild.id)
         self.sql.execute(delet)
         self.cache.pop(guild, None)

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -107,7 +107,7 @@ class WelcomeModel:
                 ]) \
                 .where(self.tb_welcome.c.guild_id == guild.id)
         result = self.sql.execute(sel)
-        welcome_message, welcome_channel_id = result.fetchone()
+        welcome_message, goodbye_message, welcome_channel_id = result.fetchone()
 
         welcome = WelcomeStorage(guild, welcome_message, goodbye_message, welcome_channel_id)
         self.cache[guild] = welcome

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -165,6 +165,9 @@ class WelcomeModel:
         self.cache[guild].delete_on_agree = value
 
     def set_welcome_channel(self, guild, channel):
+        if channel is not None:
+            assert guild == channel.guild
+
         if channel is None:
             logger.info("Unsetting welcome channel for guild '%s' (%d)",
                     guild.name, guild.id)

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -1,0 +1,131 @@
+#
+# sql/models/welcome.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+'''
+Has the model for managing the welcome cog and its functionality.
+'''
+
+# False positive when using SQLAlchemy decorators
+# pylint: disable=no-value-for-parameter
+
+import functools
+import logging
+
+import discord
+from sqlalchemy import and_, or_
+from sqlalchemy import BigInteger, Column, Table, Unicode
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.sql import select
+
+from ..hooks import register_hook
+
+Column = functools.partial(Column, nullable=False)
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'WelcomeModel',
+    'WelcomeStorage',
+]
+
+class WelcomeStorage:
+    __slots__ = (
+        'guild',
+        'welcome_message',
+        'welcome_channel',
+    )
+
+    def __init__(self, guild, welcome_message, welcome_channel_id):
+        self.guild = guild
+        self.welcome_message = welcome_message
+        self.welcome_channel = discord.utils.get(guild.roles, id=welcome_channel_id)
+
+    @property
+    def message(self):
+        return self.welcome_message
+
+    @property
+    def channel(self):
+        return self.welcome_channel
+
+class WelcomeModel:
+    __slots__ = (
+        'sql',
+        'tb_welcome',
+        'cache',
+    )
+
+    def __init__(self, sql, meta):
+        self.sql = sql
+        self.tb_welcome = Table('welcome', meta,
+                Column('guild_id', BigInteger, ForeignKey('guilds.guild_id'), primary_key=True),
+                Column('welcome_message', Unicode, nullable=True),
+                Column('welcome_channel_id', BigInteger, nullable=True))
+        self.cache = {}
+
+        register_hook('on_guild_join', self.add_welcome)
+        register_hook('on_guild_leave', self.del_welcome)
+
+    def add_welcome(self, guild):
+        logger.info("Adding welcome message row for guild '%s' (%d)", guild.name, guild.id)
+        ins = self.tb_welcome \
+                .insert() \
+                .values(guild_id=guild.id, welcome_message=None, welcome_channel_id=None)
+        self.sql.execute(ins)
+        self.cache[guild] = WelcomeStorage(guild, None, None)
+
+    def del_welcome(self, guild):
+        logger.info("Removing welcome message row for guild '%s' (%d)", guild.name, guild.id)
+        delet = self.tb_welcome \
+                .where(self.tb_welcome.c.guild_id == guild.id)
+        self.sql.execute(delet)
+        self.cache.pop(guild, None)
+
+    def get_welcome(self, guild):
+        logger.info("Getting welcome message data for guild '%s' (%d)", guild.name, guild.id)
+        if guild in self.cache:
+            logger.debug("Welcome message data found in cache, returning")
+            return self.cache[guild]
+
+        sel = select([self.tb_welcome.c.welcome_message, self.tb_welcome.c.welcome_channel_id]) \
+                .where(self.tb_welcome.c.guild_id == guild.id)
+        result = self.sql.execute(sel)
+        welcome_message, welcome_channel_id = result.fetchone()
+
+        welcome = WelcomeStorage(guild, welcome_message, welcome_channel_id)
+        self.cache[guild] = welcome
+        return welcome
+
+    def set_welcome_message(self, guild, welcome_message):
+        logger.info("Setting welcome message to %r for guild '%s' (%d)",
+                welcome_message, guild.name, guild.id)
+
+        upd = self.tb_welcome \
+                .update() \
+                .where(self.tb_welcome.c.guild_id == guild.id) \
+                .values(welcome_message=welcome_message)
+        self.sql.execute(upd)
+        self.cache[guild].welcome_message = welcome_message
+
+    def set_welcome_channel(self, guild, channel):
+        if channel is None:
+            logger.info("Unsetting welcome channel for guild '%s' (%d)",
+                    guild.name, guild.id)
+        else:
+            logger.info("Setting welcome channel to #%s (%d) for guild '%s' (%d)",
+                    channel.name, channel.id, guild.name, guild.id)
+
+        upd = self.tb_welcome \
+                .update() \
+                .where(self.tb_welcome.c.guild_id == guild.id) \
+                .values(welcome_channel_id=getattr(channel, 'id', None))
+        self.sql.execute(upd)
+        self.cache[guild].welcome_channel = channel

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -114,6 +114,11 @@ class WelcomeModel:
                 ]) \
                 .where(self.tb_welcome.c.guild_id == guild.id)
         result = self.sql.execute(sel)
+
+        if not result.rowcount:
+            self.add_welcome(guild)
+            return self.cache[guild]
+
         welcome_message, goodbye_message, welcome_channel_id = result.fetchone()
 
         welcome = WelcomeStorage(guild, welcome_message, goodbye_message, welcome_channel_id)


### PR DESCRIPTION
Fixes #70 
**Requires #71**

`!prefix` returns the current prefix and can be used by anybody.
`!prefix [xy za]` sets the prefix. Can only be used by moderators or above. A trailing `_` adds a space to the end.
`!prefix _` unsets the prefix.