### PR TITLE
Check usernames and nicknames against the text filter

### DIFF
--- a/futaba/cogs/filter/__init__.py
+++ b/futaba/cogs/filter/__init__.py
@@ -25,4 +25,6 @@ def setup(bot):
     cog = Filtering(bot)
     bot.add_listener(cog.check_message, 'on_message')
     bot.add_listener(cog.check_message_edit, 'on_message_edit')
+    bot.add_listener(cog.check_member_join, 'on_member_join')
+    bot.add_listener(cog.check_member_update, 'on_member_update')
     bot.add_cog(cog)

--- a/futaba/cogs/filter/check.py
+++ b/futaba/cogs/filter/check.py
@@ -27,10 +27,14 @@ from futaba.utils import URL_REGEX, escape_backticks
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    'MASK_NICK',
     'check_message',
     'check_message_edit',
     'check_member_update',
 ]
+
+# The nickname to apply to cover up an offensive username
+MASK_NICK = 'XXX'
 
 FoundTextViolation = namedtuple('FoundTextViolation', (
     'journal',
@@ -408,7 +412,7 @@ async def check_name_filter(cog, name, name_type, member):
         if name_type == NameType.USER:
             jail_anyways = True
             await member.edit(
-                nick='XXX',
+                nick=MASK_NICK,
                 reason='Hid username for violating {filter_type.value} level name filter',
             )
         elif name_type == NameType.NICK:
@@ -513,4 +517,8 @@ async def check_member_update(cog, before, after):
         await check_name_filter(cog, after.name, NameType.USER, after)
 
     if before.nick != after.nick and after.nick is not None:
+        if after.nick == MASK_NICK:
+            logger.debug("User has masked nickname, ignoring")
+            return
+
         await check_name_filter(cog, after.nick, NameType.NICK, after)

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -25,7 +25,7 @@ from futaba import permissions
 from futaba.enums import FilterType
 from futaba.exceptions import CommandFailed, SendHelp
 from futaba.utils import async_partial, escape_backticks
-from .check import check_message, check_message_edit
+from .check import check_message, check_message_edit, check_member_join, check_member_update
 from .filter import Filter
 from .manage import add_filter, delete_filter, show_filter
 from .manage import check_hashsums, add_content_filter, delete_content_filter, show_content_filter
@@ -44,6 +44,8 @@ class Filtering:
         'content_filters',
         'check_message',
         'check_message_edit',
+        'check_member_join',
+        'check_member_update',
     )
 
     def __init__(self, bot):
@@ -53,6 +55,8 @@ class Filtering:
         self.content_filters = defaultdict(dict)
         self.check_message = async_partial(check_message, self)
         self.check_message_edit = async_partial(check_message_edit, self)
+        self.check_member_join = async_partial(check_member_join, self)
+        self.check_member_update = async_partial(check_member_update, self)
 
         logger.info("Fetching previously stored filters")
         sql = self.bot.sql.filter

--- a/futaba/enums.py
+++ b/futaba/enums.py
@@ -40,6 +40,11 @@ class MemberLeaveType(Enum):
     BANNED = 'banned'
 
 @unique
+class NameType(Enum):
+    USER = 'username'
+    NICK = 'nickname'
+
+@unique
 class FilterType(Enum):
     FLAG = 'flag'
     BLOCK = 'block'


### PR DESCRIPTION
Fixes #40 

Respects user immunity lists, only checks guild text filters.
At the "flag" level a notification is given.
At the "block" level the nickname is removed, or for usernames, they are dunced and given a nickname to hide their name.
At the "jail" level they are always jailed, and the name removal from above is applied.