### PR TITLE
Add join alerts

### DIFF
--- a/futaba/cogs/filter/check.py
+++ b/futaba/cogs/filter/check.py
@@ -175,11 +175,15 @@ def filter_immune(bot, guild, member, channel=None):
     if member.id in bot.config.owner_ids:
         return True
 
+    # Fetch most specific permissions
+    if channel is None:
+        perms = member.guild_permissions
+    else:
+        perms = channel.permissions_for(member)
+
     # Check admins
-    perms = channel.permissions_for(member)
-    if channel is not None:
-        if perms.manage_guild:
-            return True
+    if perms.manage_guild:
+        return True
 
     # Check moderators (if enabled)
     if filter_settings.manage_messages_immune:

--- a/futaba/cogs/welcome/__init__.py
+++ b/futaba/cogs/welcome/__init__.py
@@ -10,6 +10,7 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
+from .alert import Alert
 from .core import Welcome
 
 
@@ -17,6 +18,10 @@ def setup(bot):
     """
     Setup for bot to add cog
     """
+
+    cog = Alert(bot)
+    bot.add_listener(cog.member_join, "on_member_join")
+    bot.add_cog(cog)
 
     cog = Welcome(bot)
     bot.add_listener(cog.member_join, "on_member_join")

--- a/futaba/cogs/welcome/alert.py
+++ b/futaba/cogs/welcome/alert.py
@@ -16,14 +16,13 @@ configured by staff. If so, a notification is sent to /welcome/alert.
 """
 
 import logging
-from collections import defaultdict
 
 import discord
 from discord.ext import commands
 
 from futaba import permissions
 from futaba.enums import JoinAlertKey, ValueRelationship
-from futaba.exceptions import ManualCheckFailure, SendHelp
+from futaba.exceptions import CommandFailed, ManualCheckFailure, SendHelp
 from futaba.str_builder import StringBuilder
 from futaba.unicode import normalize_caseless
 
@@ -33,9 +32,10 @@ __all__ = ["JoinAlert", "Alert"]
 
 
 class JoinAlert:
-    __slots__ = ("key", "op", "value")
+    __slots__ = ("id", "key", "op", "value")
 
-    def __init__(self, key, op, value):
+    def __init__(self, id, key, op, value):
+        self.id = id
         self.key = key
         self.op = op
         self.value = value
@@ -62,21 +62,22 @@ class Alert:
     def __init__(self, bot):
         self.bot = bot
         self.journal = bot.get_broadcaster("/welcome/alert")
-        self.alerts = defaultdict(dict)
+        self.alerts = {}
 
         for guild in bot.guilds:
             alert_parts = bot.sql.welcome.get_all_alerts(guild)
-            for key, op, value in alert_parts:
-                alert = JoinAlert(key, op, value)
-                self.alerts[guild][key] = alert
+            for id, key, op, value in alert_parts:
+                alert = JoinAlert(id, key, op, value)
+                self.alerts[id] = alert
 
     async def member_join(self, member):
         logger.info("Member '%s' (%d) joined, checking alerts.", member.name, member.id)
-        for alert in self.alerts[member.guild].values():
-            if alert.matches(member):
-                logger.info("Matches alert: %s!", alert)
-                content = f"Member {member.mention} violates alert: {alert}"
-                self.journal.send("", member.guild, content, icon="found")
+        for alert in self.alerts.values():
+            if alert.guild == member.guild:
+                if alert.matches(member):
+                    logger.info("Matches alert: %s!", alert)
+                    content = f"Member {member.mention} violates alert: {alert}"
+                    self.journal.send("", member.guild, content, icon="found")
 
     @commands.group(name="joinalert", aliases=["jalert"])
     @commands.guild_only()
@@ -100,10 +101,12 @@ class Alert:
         embed.set_author(name="Join alerts")
         descr = StringBuilder()
 
-        for alert in self.alerts[ctx.guild].values():
-            descr.writeln(f"- `{alert}`")
+        descr.writeln("__Alert ID__ | __Condition__")
+        for alert in self.alerts.values():
+            assert alert.id is not None, "Alert was not given an ID"
+            descr.writeln(f"#**`{alert.id:05}`** | `{alert}`")
 
-        if descr:
+        if self.alerts:
             embed.colour = discord.Colour.dark_teal()
             embed.description = str(descr)
         else:
@@ -115,7 +118,7 @@ class Alert:
     @alert.command(name="add", aliases=["append", "extend"])
     @commands.guild_only()
     @permissions.check_mod()
-    async def alert_add(self, ctx, attribute: str, relationship: str, amount: str):
+    async def alert_add(self, ctx, attribute: str, relationship: str, *, amount: str):
         """
         Adds a join alert with the given condition.
 
@@ -144,35 +147,30 @@ class Alert:
         except ValueError as error:
             raise ManualCheckFailure(content=str(error))
 
-        alert = JoinAlert(key, op, value)
+        alert = JoinAlert(None, key, op, value)
         logging.info("Adding join alert: %s", alert)
 
         with self.bot.sql.transaction():
             self.bot.sql.welcome.add_alert(ctx.guild, alert)
 
-        self.alerts[ctx.guild][key] = alert
+        self.alerts[alert.id] = alert
 
         # Notify the user
         embed = discord.Embed(colour=discord.Colour.dark_teal())
         embed.set_author(name="Successfully added join alert")
         descr = StringBuilder()
-        descr.writeln(f"- `{alert}`")
+        descr.writeln(f"ID: #`{alert.id:05}`, Condition: `{alert}`")
         descr.writeln(
             "To get these notifications in a channel, add a logger for path `/welcome/alert`"
         )
         embed.description = str(descr)
-
         await ctx.send(embed=embed)
 
     @alert.command(name="remove", aliases=["rm", "delete", "del"])
     @commands.guild_only()
     @permissions.check_mod()
-    async def alert_remove(self, ctx, attribute: str):
-        """
-        If there exists a join alert tracking the given attribute, delete it.
-
-        Possible attributes: id, created, name, discrim, avatar, status
-        """
+    async def alert_remove(self, ctx, id: int):
+        """ Delete the join alert with the given attribute. """
 
         logging.info(
             "Got request to delete join alert for '%s' (%d)",
@@ -180,13 +178,14 @@ class Alert:
             ctx.guild.id,
         )
 
-        try:
-            key = JoinAlertKey.parse(attribute)
-        except ValueError:
-            raise ManualCheckFailure(content=f"Invalid attribute: {attribute}")
-
-        logging.info("Removing join alert: %s", key)
+        logging.info("Removing join alert for id: %d", id)
         with self.bot.sql.transaction():
-            self.bot.sql.welcome.remove_alert(ctx.guild, key)
+            try:
+                self.bot.sql.welcome.remove_alert(ctx.guild, id)
+            except ValueError:
+                embed = discord.Embed(colour=discord.Colour.red())
+                embed.set_author(name="Deletion failed")
+                embed.description = f"No such join alert id: `{id}`"
+                raise CommandFailed(embed=embed)
 
-        self.alerts[ctx.guild].pop(key, None)
+        del self.alerts[id]

--- a/futaba/cogs/welcome/alert.py
+++ b/futaba/cogs/welcome/alert.py
@@ -1,0 +1,117 @@
+#
+# cogs/welcome/alert.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+"""
+Cog for checking new members and seeing if they match a join alert
+configured by staff. If so, a notification is sent to /welcome/alert.
+"""
+
+import asyncio
+import logging
+from collections import defaultdict
+
+import discord
+from discord.ext import commands
+
+from futaba import permissions
+from futaba.enums import JoinAlertKey, ValueRelationship
+from futaba.exceptions import BadArgument, CommandFailed, SendHelp
+from futaba.unicode import normalize_caseless
+
+logger = logging.getLogger(__package__)
+
+__all__ = ["JoinAlert", "Alert"]
+
+
+class JoinAlert:
+    __slots__ = ("key", "op", "value")
+
+    def __init__(self, key, op, value):
+        self.key = key
+        self.op = op
+        self.value = value
+
+    def matches(self, member, value):
+        member_value = getattr(member, self.key.value)
+        if isinstance(value, str) and isinstance(member_value, str):
+            value = normalize_caseless(value)
+            member_value = normalize_caseless(member_value)
+        return self.op.comparator(value, member_value)
+
+
+class Alert:
+    __slots__ = ("bot", "journal", "alerts")
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.journal = bot.get_broadcaster("/welcome")
+        self.alerts = defaultdict(dict)
+
+        for guild in bot.guilds:
+            alert_parts = bot.sql.welcome.get_all_alerts(guild)
+            for key, op, value in alert_parts:
+                alert = JoinAlert(key, op, value)
+                self.alerts[guild][key] = alert
+
+    async def member_join(self, member):
+        pass
+
+    @commands.group(name="joinalert", aliases=["jalert"])
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def alert(self, ctx):
+        """ Manages the welcome cog for managing new users and roles. """
+
+        if ctx.invoked_subcommand is None:
+            raise SendHelp()
+
+    @alert.command(name="add", aliases=["append", "extend"])
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def alert_add(self, ctx, attribute: str, relationship: str, amount: str):
+        """
+        Adds a join alert with the given condition.
+
+        Possible attributes: id, created, name, discrim, avatar, status
+        Possible relationships: > >= = != < <= ~
+        """
+
+        logging.info(
+            "Got request to add new join alert for '%s' (%d)",
+            ctx.guild.name,
+            ctx.guild.id,
+        )
+
+        try:
+            key = JoinAlertKey.parse(attribute)
+        except ValueError:
+            raise BadArgument(f"Invalid attribute: {key}")
+
+        try:
+            op = ValueRelationship(relationship)
+        except ValueError:
+            raise BadArgument(f"Invalid relationship: {relationship}")
+
+        try:
+            value = key.parse_value(amount)
+        except ValueError as error:
+            raise BadArgument(str(error))
+
+        logging.info("Adding join alert: %s %s %s", attribute, relationship, amount)
+        alert = JoinAlert(key, op, value)
+
+        with self.bot.sql.transaction():
+            self.bot.sql.welcome.add_alert(ctx.guild, alert)
+
+        self.alerts[ctx.guild] = alert
+
+    # TODO list and remove

--- a/futaba/enums.py
+++ b/futaba/enums.py
@@ -31,7 +31,7 @@ class Reactions(Enum):
 @unique
 class JoinAlertKey(Enum):
     CREATION = "created_at"  # datetime
-    ID = "user_id"  # int
+    ID = "id"  # int
     NAME = "name"  # str
     DISCRIM = "discriminator"  # str
     AVATAR = "avatar"  # Optional[str]

--- a/futaba/enums.py
+++ b/futaba/enums.py
@@ -108,6 +108,10 @@ class ValueRelationship(Enum):
     def comparator(self):
         return VALUE_RELATIONSHIP_COMPARATORS[self]
 
+    @property
+    def symbol(self):
+        return VALUE_RELATIONSHIP_SYMBOLS[self]
+
 
 VALUE_RELATIONSHIP_COMPARATORS = {
     ValueRelationship.LESS_THAN: lambda x, y: x < y,
@@ -116,7 +120,17 @@ VALUE_RELATIONSHIP_COMPARATORS = {
     ValueRelationship.GREATER_OR_EQUAL: lambda x, y: x >= y,
     ValueRelationship.EQUAL_TO: lambda x, y: x == y,
     ValueRelationship.NOT_EQUAL: lambda x, y: x != y,
-    ValueRelationship.CONTAINS: lambda x, y: x in y,
+    ValueRelationship.CONTAINS: lambda x, y: y in x,
+}
+
+VALUE_RELATIONSHIP_SYMBOLS = {
+    ValueRelationship.LESS_THAN: "<",
+    ValueRelationship.LESS_OR_EQUAL: "\N{LESS-THAN OR EQUAL TO}",
+    ValueRelationship.GREATER_THAN: ">",
+    ValueRelationship.GREATER_OR_EQUAL: "\N{GREATER-THAN OR EQUAL TO}",
+    ValueRelationship.EQUAL_TO: "=",
+    ValueRelationship.NOT_EQUAL: "\N{NOT EQUAL TO}",
+    ValueRelationship.CONTAINS: "\N{ALMOST EQUAL TO}",
 }
 
 

--- a/futaba/enums.py
+++ b/futaba/enums.py
@@ -12,9 +12,8 @@
 
 from enum import Enum, unique
 
+import dateparser
 import discord
-
-__all__ = ["Reactions", "MemberLeaveType", "FilterType", "LocationType"]
 
 
 @unique
@@ -27,6 +26,98 @@ class Reactions(Enum):
 
     async def add(self, message: discord.Message):
         await message.add_reaction(self.value)
+
+
+@unique
+class JoinAlertKey(Enum):
+    CREATION = "created_at"  # datetime
+    ID = "user_id"  # int
+    NAME = "name"  # str
+    DISCRIM = "discriminator"  # str
+    AVATAR = "avatar"  # Optional[str]
+    STATUS = "status"  # discord.Status
+
+    @classmethod
+    def parse(cls, arg):
+        if arg in ("created", "creation", "created at", "created_at"):
+            return cls.CREATION
+        elif arg in ("id", "user id", "member id", "user_id"):
+            return cls.ID
+        elif arg in ("name", "username"):
+            return cls.NAME
+        elif arg in ("discrim", "discriminator"):
+            return cls.DISCRIM
+        elif arg in ("avatar", "avatar hash"):
+            return cls.AVATAR
+        elif arg in ("status", "user status"):
+            return cls.STATUS
+        else:
+            raise ValueError(f"No JoinAlertKey for value: {arg}")
+
+    def parse_value(self, arg):
+        if self == JoinAlertKey.CREATION:
+            date = dateparser.parse(arg)
+            if date is None:
+                raise ValueError(f"Unknown date/time: {arg}")
+            return date
+        elif self == JoinAlertKey.ID:
+            try:
+                id = int(arg)
+                if id < 0 or id > 2 ** 63 - 1:
+                    raise ValueError()
+            except ValueError:
+                # Raise with different message
+                raise ValueError(f"Invalid discord ID: {arg}")
+            else:
+                return id
+        elif self == JoinAlertKey.NAME:
+            return arg
+        elif self == JoinAlertKey.DISCRIM:
+            try:
+                discrim = int(arg)
+                if discrim <= 1 or discrim > 9999:
+                    raise ValueError()
+            except ValueError:
+                # Raise with different message
+                raise ValueError(f"Invalid discriminator: {arg}")
+            else:
+                return f"{discrim:04}"
+        elif self == JoinAlertKey.AVATAR:
+            return arg or None
+        elif self == JoinAlertKey.STATUS:
+            try:
+                return discord.Status(arg.lower())
+            except ValueError:
+                # Raise with different message
+                raise ValueError(f"Invalid discord status: {arg}")
+        else:
+            raise ValueError(f"Not an enum instance of JoinAlertKey")
+
+
+@unique
+class ValueRelationship(Enum):
+    LESS_THAN = "<"
+    GREATER_THAN = ">"
+    LESS_OR_EQUAL = "<="
+    GREATER_OR_EQUAL = ">="
+    EQUAL_TO = "="
+    NOT_EQUAL = "!="
+    CONTAINS = "~"
+
+    @property
+    def comparator(self):
+        return VALUE_RELATIONSHIP_COMPARATORS[self]
+
+
+VALUE_RELATIONSHIP_COMPARATORS = {
+    ValueRelationship.LESS_THAN: lambda x, y: x < y,
+    ValueRelationship.LESS_OR_EQUAL: lambda x, y: x <= y,
+    ValueRelationship.GREATER_THAN: lambda x, y: x > y,
+    ValueRelationship.GREATER_OR_EQUAL: lambda x, y: x >= y,
+    ValueRelationship.EQUAL_TO: lambda x, y: x == y,
+    ValueRelationship.NOT_EQUAL: lambda x, y: x != y,
+    ValueRelationship.CONTAINS: lambda x, y: x in y,
+}
 
 
 @unique

--- a/futaba/enums.py
+++ b/futaba/enums.py
@@ -93,6 +93,23 @@ class JoinAlertKey(Enum):
         else:
             raise ValueError(f"Not an enum instance of JoinAlertKey")
 
+    @property
+    def display_name(self):
+        if self == JoinAlertKey.CREATION:
+            return "account creation date"
+        elif self == JoinAlertKey.ID:
+            return "user id"
+        elif self == JoinAlertKey.NAME:
+            return "username"
+        elif self == JoinAlertKey.DISCRIM:
+            return "discriminator"
+        elif self == JoinAlertKey.AVATAR:
+            return "avatar hash"
+        elif self == JoinAlertKey.STATUS:
+            return "status"
+        else:
+            raise ValueError(f"Not an enum instance of JoinAlertKey")
+
 
 @unique
 class ValueRelationship(Enum):

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -103,7 +103,6 @@ class WelcomeModel:
             Column("delete_on_agree", Boolean),
             Column("welcome_channel_id", BigInteger, nullable=True),
         )
-        # TODO allow multiple flags with the same key
         self.tb_join_alerts = Table(
             "join_alerts",
             meta,

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -95,6 +95,7 @@ class WelcomeModel:
             Column("delete_on_agree", Boolean),
             Column("welcome_channel_id", BigInteger, nullable=True),
         )
+        # TODO allow multiple flags with the same key
         self.tb_join_alerts = Table(
             "join_alerts",
             meta,
@@ -289,6 +290,7 @@ class WelcomeModel:
                 value=str(alert.value),
             )
             self.sql.execute(ins)
+        # TODO add to cache
 
     def remove_alert(self, guild, key):
         logger.info("Remove join alert for guild '%s' (%d)", guild.name, guild.id)
@@ -300,6 +302,7 @@ class WelcomeModel:
             )
         )
         result = self.sql.execute(delet)
+        # TODO remove from cache
         assert result.rowcount() in (0, 1), "Multiple rows deleted"
 
     def get_all_alerts(self, guild):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ git+https://github.com/Rapptz/discord.py@rewrite#egg=discord.py
 SQLAlchemy>=1.0
 aiohttp>=2.2
 confusable_homoglyphs>=3.0
+dateparser>=0.7
 psycopg2>=2.5
 textdistance>=3.0
 toml>=0.9


### PR DESCRIPTION
Allows moderators to set, list, and check join alerts, or simple conditionals that are checked when a new member joins the guild. This allows, for instance, staff to be notified if a particularly rowdy user ever decides to rejoin at a later date.