### PR TITLE
Have only nightly python allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,14 @@ jobs:
   include:
     - stage: check
       python: '3.6'
-      script: black --check futaba
+      script:
+        - black --check futaba
+    - stage: build
+      script:
+        # Display all lints and a report
+        # Only fail on errors
+        - pylint --reports=yes futaba || true
+        - pylint --errors-only futaba
 
 matrix:
   allow_failures:
@@ -26,12 +33,6 @@ matrix:
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
-
-script:
-  # Display all lints and a report
-  # Only fail on errors
-  - pylint --reports=yes futaba || true
-  - pylint --errors-only futaba
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: pip
 
 stages:
   - check
-  - build
+  - test
 
 python:
   - '3.6'
@@ -18,12 +18,6 @@ jobs:
       python: '3.6'
       script:
         - black --check futaba
-    - stage: build
-      script:
-        # Display all lints and a report
-        # Only fail on errors
-        - pylint --reports=yes futaba || true
-        - pylint --errors-only futaba
 
 matrix:
   allow_failures:
@@ -33,6 +27,12 @@ matrix:
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
+
+script:
+  # Display all lints and a report
+  # Only fail on errors
+  - pylint --reports=yes futaba || true
+  - pylint --errors-only futaba
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
 
 matrix:
   allow_failures:
-    - python: '3.7-dev'
     - python: 'nightly'
   fast_finish: true
 
@@ -20,7 +19,7 @@ install:
 
 script:
   # Run a check for black formatting
-  - black --check futaba
+  - [[ $(python --version) == "Python 3.6"* ]] && black --check futaba
 
   # Display all lints and a report
   # Only fail on errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   # Run a check for black formatting
-  - '[[ $(python --version) == "Python 3.6"* ]] && black --check futaba'
+  - '[[ $(python --version) == "Python 3.6"* ]] && black --check futaba || echo "Not checking formatting"'
 
   # Display all lints and a report
   # Only fail on errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   # Run a check for black formatting
-  - ./.travis/format_check.sh
+  - '[[ $(python --version) == "Python 3.6"* ]] && black --check futaba'
 
   # Display all lints and a report
   # Only fail on errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,20 @@ dist: trusty
 sudo: false
 cache: pip
 
+stages:
+  - check
+  - build
+
 python:
   - '3.6'
   - '3.7-dev'
   - 'nightly'
+
+jobs:
+  include:
+    - stage: check
+      python: '3.6'
+      script: black --check futaba
 
 matrix:
   allow_failures:
@@ -18,9 +28,6 @@ install:
   - pip install -r requirements-dev.txt
 
 script:
-  # Run a check for black formatting
-  - '[[ $(python --version) == "Python 3.6"* ]] && black --check futaba || echo "Not checking formatting"'
-
   # Display all lints and a report
   # Only fail on errors
   - pylint --reports=yes futaba || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   # Run a check for black formatting
-  - [[ $(python --version) == "Python 3.6"* ]] && black --check futaba
+  - ./.travis/format_check.sh
 
   # Display all lints and a report
   # Only fail on errors

--- a/.travis/format_check.sh
+++ b/.travis/format_check.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-
-if [[ $(python --version) == 'Python 3.6'* ]]; then
-	black --check futaba
-fi

--- a/.travis/format_check.sh
+++ b/.travis/format_check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [[ $(python --version) == 'Python 3.6'* ]]; then
+	black --check futaba
+fi


### PR DESCRIPTION
Doesn't run `black --check` on python versions known to fail.