### PR TITLE
Add cog for self-assignable roles

### DIFF
--- a/futaba/client.py
+++ b/futaba/client.py
@@ -233,7 +233,7 @@ class Bot(commands.AutoShardedBot):
             await Reactions.DENY.add(ctx.message)
 
         elif isinstance(error, ManualCheckFailure):
-            # Tell the user they don't have permission and reprt the error message if any
+            # Tell the user they don't have permission and report the error message if any
             logger.info("Manual permission check for command failed")
 
             if error.kwargs:

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -232,7 +232,7 @@ class Info:
 
         await ctx.send(embed=embed)
 
-    @commands.command(name="rinfo", aliases=["roleinfo", "role"])
+    @commands.command(name="rinfo", aliases=["roleinfo"])
     @commands.guild_only()
     async def rinfo(self, ctx, *, name: str = None):
         """

--- a/futaba/cogs/roles/__init__.py
+++ b/futaba/cogs/roles/__init__.py
@@ -1,5 +1,5 @@
 #
-# sql/models/__init__.py
+# cogs/roles/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
 # Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
@@ -10,15 +10,13 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-"""
-Module that contains models for interacting with SQL tables in a clean
-and abstracted way.
-"""
+from .core import SelfAssignableRoles
 
-from .alias import AliasHistoryModel
-from .filter import FilterModel
-from .guilds import GuildsModel
-from .journal import JournalModel
-from .roles import SelfAssignableRolesModel
-from .settings import SettingsModel
-from .welcome import WelcomeModel
+
+def setup(bot):
+    """
+    Setup for bot to add cog
+    """
+
+    cog = SelfAssignableRoles(bot)
+    bot.add_cog(cog)

--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -54,7 +54,7 @@ class SelfAssignableRoles:
     async def role_show(self, ctx):
         """ Shows all self-assignable roles. """
 
-        assignable_roles = self.bot.sql.roles.get_assignable_roles(ctx.guild)
+        assignable_roles = sorted(self.bot.sql.roles.get_assignable_roles(ctx.guild), key=lambda r: r.name)
         if not assignable_roles:
             prefix = self.bot.prefix(ctx.guild)
             embed = discord.Embed(colour=discord.Colour.dark_purple())

--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -1,0 +1,138 @@
+#
+# cogs/roles/core.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+"""
+Cog for maintaining a guild's list of self-assignable roles, roles which
+do not provide any special permissions, but are markers that members can
+add to themselves if they wish.
+"""
+
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from futaba import permissions
+from futaba.converters import RoleConv
+from futaba.exceptions import CommandFailed, ManualCheckFailure, SendHelp
+from futaba.str_builder import StringBuilder
+
+logger = logging.getLogger(__package__)
+
+
+class SelfAssignableRoles:
+    __slots__ = ("bot", "journal")
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.journal = bot.get_broadcaster("/roles")
+
+    @commands.group(name="role", aliases=["roles", "sar"])
+    @commands.guild_only()
+    async def role(self, ctx):
+        """ Manages self-assignable roles for this guild. """
+
+        if ctx.invoked_subcommand is None:
+            raise SendHelp()
+
+    @role.command(name="show", aliases=["display", "list", "lsar", "ls"])
+    @commands.guild_only()
+    async def role_show(self, ctx):
+        """ Shows all self-assignable roles. """
+
+        ...
+
+    @role.command(name="add", aliases=["join", "give", "set", "update"])
+    @commands.guild_only()
+    async def role_add(self, ctx, *roles: RoleConv):
+        """ Joins the given self-assignable roles. """
+
+        if not roles:
+            raise CommandFailed()
+
+        ...
+
+    @role.command(
+        name="remove", aliases=["rm", "delete", "del", "leave", "take", "unset"]
+    )
+    @commands.guild_only()
+    async def role_remove(self, ctx, *roles: RoleConv):
+        """ Leaves the given self-assignable roles. """
+
+        if not roles:
+            raise CommandFailed()
+
+        ...
+
+    @role.command(name="joinable", aliases=["assignable", "canjoin"])
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def role_joinable(self, ctx, *roles: RoleConv):
+        """ Allows a moderator to add roles to the self-assignable group. """
+
+        logger.info(
+            "Adding joinable roles for guild '%s' (%d): [%s]",
+            ctx.guild.name,
+            ctx.guild.id,
+            ", ".join(role.name for role in roles),
+        )
+
+        if not roles:
+            raise CommandFailed()
+
+        # Ensure none of the roles grant any permissions
+        for role in roles:
+            embed = permissions.elevated_role_embed(ctx.guild, role, "error")
+            if embed is not None:
+                raise ManualCheckFailure(embed=embed)
+
+        # Add roles to database
+        with self.bot.sql.transaction():
+            for role in roles:
+                self.bot.sql.roles.add_assignable_role(ctx.guild, role)
+
+    @role.command(name="unjoinable", aliases=["unassignable", "cannotjoin", "nojoin"])
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def role_unjoinable(self, ctx, *roles: RoleConv):
+        """ Allows a moderator to remove roles from the self-assignable group. """
+
+        logger.info(
+            "Removing joinable roles for guild '%s' (%d): [%s]",
+            ctx.guild.name,
+            ctx.guild.id,
+            ", ".join(role.name for role in roles),
+        )
+
+        if not roles:
+            raise CommandFailed()
+
+        # Make a copy of joinable roles before the delete
+        assignable_roles = frozenset(self.bot.sql.roles.get_assignable_roles(ctx.guild))
+
+        # Remove roles from database
+        with self.bot.sql.transaction():
+            for role in roles:
+                self.bot.sql.roles.remove_assignable_role(ctx.guild, role)
+
+        # Send response if not all roles were removed
+        not_removed = frozenset(roles) - assignable_roles
+        if not_removed:
+            embed = discord.Embed(colour=discord.Colour.dark_purple())
+            embed.set_author(name="Not all roles removed")
+            descr = StringBuilder()
+            descr.writeln("The following roles were not assignable to begin with:")
+            for role in not_removed:
+                descr.writeln(f"- {role.mention}")
+            embed.description = str(descr)
+            await ctx.send(embed=embed)

--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -96,7 +96,7 @@ class SelfAssignableRoles:
         """ Joins the given self-assignable roles. """
 
         self.check_roles(ctx, roles)
-        await ctx.author.add_roles(roles, reason='Adding self-assignable roles', atomic=True)
+        await ctx.author.add_roles(*roles, reason='Adding self-assignable roles', atomic=True)
 
     @role.command(
         name="remove", aliases=["rm", "delete", "del", "leave", "take", "unset"]
@@ -106,7 +106,7 @@ class SelfAssignableRoles:
         """ Leaves the given self-assignable roles. """
 
         self.check_roles(ctx, roles)
-        await ctx.author.remove_roles(roles, reason='Removing self-assignable roles', atomic=True)
+        await ctx.author.remove_roles(*roles, reason='Removing self-assignable roles', atomic=True)
 
     @role.command(name="joinable", aliases=["assignable", "canjoin"])
     @commands.guild_only()

--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -54,19 +54,21 @@ class SelfAssignableRoles:
     async def role_show(self, ctx):
         """ Shows all self-assignable roles. """
 
-        assignable_roles = sorted(self.bot.sql.roles.get_assignable_roles(ctx.guild), key=lambda r: r.name)
+        assignable_roles = sorted(
+            self.bot.sql.roles.get_assignable_roles(ctx.guild), key=lambda r: r.name
+        )
         if not assignable_roles:
             prefix = self.bot.prefix(ctx.guild)
             embed = discord.Embed(colour=discord.Colour.dark_purple())
-            embed.set_author(name='No self-assignable roles')
-            embed.description = f'Use the `{prefix}role joinable/unjoinable` commands to change this list!'
+            embed.set_author(name="No self-assignable roles")
+            embed.description = f"Use the `{prefix}role joinable/unjoinable` commands to change this list!"
             await ctx.send(embed=embed)
             return
 
         embed = discord.Embed(colour=discord.Colour.dark_teal())
-        embed.set_author(name='Self-assignable roles')
+        embed.set_author(name="Self-assignable roles")
 
-        descr = StringBuilder(sep=', ')
+        descr = StringBuilder(sep=", ")
         for role in assignable_roles:
             descr.write(role.mention)
         embed.description = str(descr)
@@ -81,13 +83,15 @@ class SelfAssignableRoles:
         for role in roles:
             if role not in assignable_roles:
                 embed = discord.Embed(colour=discord.Colour.red())
-                embed.set_author(name='Role not assignable')
-                embed.description = f'The role {role.mention} cannot be self-assigned'
+                embed.set_author(name="Role not assignable")
+                embed.description = f"The role {role.mention} cannot be self-assigned"
                 raise CommandFailed(embed=embed)
             elif role >= ctx.me.top_role:
                 embed = discord.Embed(colour=discord.Colour.red())
-                embed.set_author(name='Error assigning roles')
-                embed.description = f'Cannot assign {role.mention}, which is above me in the hierarchy'
+                embed.set_author(name="Error assigning roles")
+                embed.description = (
+                    f"Cannot assign {role.mention}, which is above me in the hierarchy"
+                )
                 raise ManualCheckFailure(embed=embed)
 
     @role.command(name="add", aliases=["join", "give", "set", "update"])
@@ -96,7 +100,9 @@ class SelfAssignableRoles:
         """ Joins the given self-assignable roles. """
 
         self.check_roles(ctx, roles)
-        await ctx.author.add_roles(*roles, reason='Adding self-assignable roles', atomic=True)
+        await ctx.author.add_roles(
+            *roles, reason="Adding self-assignable roles", atomic=True
+        )
 
     @role.command(
         name="remove", aliases=["rm", "delete", "del", "leave", "take", "unset"]
@@ -106,7 +112,9 @@ class SelfAssignableRoles:
         """ Leaves the given self-assignable roles. """
 
         self.check_roles(ctx, roles)
-        await ctx.author.remove_roles(*roles, reason='Removing self-assignable roles', atomic=True)
+        await ctx.author.remove_roles(
+            *roles, reason="Removing self-assignable roles", atomic=True
+        )
 
     @role.command(name="joinable", aliases=["assignable", "canjoin"])
     @commands.guild_only()
@@ -141,14 +149,16 @@ class SelfAssignableRoles:
 
         # Send response
         embed = discord.Embed(colour=discord.Colour.dark_teal())
-        embed.set_author(name='Made roles joinable')
-        descr = StringBuilder(sep=', ')
+        embed.set_author(name="Made roles joinable")
+        descr = StringBuilder(sep=", ")
         for role in roles:
             descr.write(role.mention)
         embed.description = str(descr)
         await ctx.send(embed=embed)
 
-    @role.command(name="unjoinable", aliases=["unassignable", "cantjoin", "cannotjoin", "nojoin"])
+    @role.command(
+        name="unjoinable", aliases=["unassignable", "cantjoin", "cannotjoin", "nojoin"]
+    )
     @commands.guild_only()
     @permissions.check_mod()
     async def role_unjoinable(self, ctx, *roles: RoleConv):
@@ -171,8 +181,8 @@ class SelfAssignableRoles:
 
         # Send response
         embed = discord.Embed(colour=discord.Colour.dark_teal())
-        embed.set_author(name='Made roles not joinable')
-        descr = StringBuilder(sep=', ')
+        embed.set_author(name="Made roles not joinable")
+        descr = StringBuilder(sep=", ")
         for role in roles:
             descr.write(role.mention)
         embed.description = str(descr)

--- a/futaba/sql/handle.py
+++ b/futaba/sql/handle.py
@@ -23,6 +23,7 @@ from .models import (
     FilterModel,
     GuildsModel,
     JournalModel,
+    SelfAssignableRolesModel,
     SettingsModel,
     WelcomeModel,
 )
@@ -43,6 +44,7 @@ class SqlHandler:
         "filter",
         "guilds",
         "journal",
+        "roles",
         "settings",
         "welcome",
     )
@@ -59,6 +61,7 @@ class SqlHandler:
         self.filter = FilterModel(self, meta)
         self.guilds = GuildsModel(self, meta)
         self.journal = JournalModel(self, meta)
+        self.roles = SelfAssignableRolesModel(self, meta)
         self.settings = SettingsModel(self, meta)
         self.welcome = WelcomeModel(self, meta)
 

--- a/futaba/sql/models/roles.py
+++ b/futaba/sql/models/roles.py
@@ -22,8 +22,8 @@ import logging
 from collections import defaultdict
 
 import discord
-from sqlalchemy import and_, or_
-from sqlalchemy import BigInteger, Column, Table, Unicode
+from sqlalchemy import and_
+from sqlalchemy import BigInteger, Column, Table
 from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.sql import select
 

--- a/futaba/sql/models/roles.py
+++ b/futaba/sql/models/roles.py
@@ -75,7 +75,7 @@ class SelfAssignableRolesModel:
         result = self.sql.execute(sel)
 
         roles = set()
-        for role_id, in result.fetchall():
+        for (role_id,) in result.fetchall():
             role = discord.utils.get(guild.roles, id=role_id)
             if role is not None:
                 roles.add(role)

--- a/futaba/sql/models/roles.py
+++ b/futaba/sql/models/roles.py
@@ -1,0 +1,103 @@
+#
+# sql/models/roles.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+"""
+Model for storing the configured self-assignable roles within a guild.
+"""
+
+# False positive when using SQLAlchemy decorators
+# pylint: disable=no-value-for-parameter
+
+import functools
+import logging
+from collections import defaultdict
+
+import discord
+from sqlalchemy import and_, or_
+from sqlalchemy import BigInteger, Column, Table, Unicode
+from sqlalchemy import ForeignKey, UniqueConstraint
+from sqlalchemy.sql import select
+
+from ..hooks import register_hook
+
+Column = functools.partial(Column, nullable=False)
+logger = logging.getLogger(__name__)
+
+__all__ = ["SelfAssignableRolesModel"]
+
+
+class SelfAssignableRolesModel:
+    __slots__ = ("sql", "tb_assignable_roles", "roles_cache")
+
+    def __init__(self, sql, meta):
+        self.sql = sql
+        self.tb_assignable_roles = Table(
+            "assignable_roles",
+            meta,
+            Column("guild_id", BigInteger, ForeignKey("guilds.guild_id")),
+            Column("role_id", BigInteger),
+            UniqueConstraint("role_id", name="assignable_roles_uq"),
+        )
+        self.roles_cache = defaultdict(set)
+
+        register_hook("on_guild_leave", self.remove_all_assignable_roles)
+
+    def remove_all_assignable_roles(self, guild):
+        logger.info(
+            "Remove all assignable roles for guild '%s' (%d)", guild.name, guild.id
+        )
+        delet = self.tb_assignable_roles.delete().where(
+            self.tb_assignable_roles.c.guild_id == guild.id
+        )
+        self.sql.execute(delet)
+        self.roles_cache.pop(guild, None)
+
+    def get_assignable_roles(self, guild):
+        logger.info(
+            "Getting all assignable roles for guild '%s' (%d)", guild.name, guild.id
+        )
+
+        if guild in self.roles_cache:
+            logger.debug("Found roles in cache, returning")
+            return self.roles_cache[guild]
+
+        sel = select([self.tb_assignable_roles.c.role_id]).where(
+            self.tb_assignable_roles.c.guild_id == guild.id
+        )
+        result = self.sql.execute(sel)
+
+        for role_id in result.fetchall():
+            role = discord.utils.get(guild.roles, id=role_id)
+            if role is not None:
+                self.roles_cache[guild].add(role)
+
+        return self.roles_cache[guild]
+
+    def add_assignable_role(self, guild, role):
+        logger.info("Adding assignable role for guild '%s' (%d)", guild.name, guild.id)
+        ins = self.tb_assignable_roles.insert().values(
+            guild_id=guild.id, role_id=role.id
+        )
+        self.sql.execute(ins)
+
+    def remove_assignable_role(self, guild, role):
+        logger.info(
+            "Removing assignable role for guild '%s' (%d)", guild.name, guild.id
+        )
+        delet = self.tb_assignable_roles.delete().where(
+            and_(
+                self.tb_assignable_roles.c.guild_id == guild.id,
+                self.tb_assignable_roles.c.role_id == role.id,
+            )
+        )
+        result = self.sql.execute(delet)
+        assert result.rowcount in (0, 1), "Multiple rows deleted"

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -158,10 +158,10 @@ class SettingsModel:
         self.roles_cache = {}
 
         register_hook("on_guild_join", self.add_guild_settings)
-        register_hook("on_guild_leave", self.del_guild_settings)
+        register_hook("on_guild_leave", self.remove_guild_settings)
 
         register_hook("on_guild_join", self.add_special_roles)
-        register_hook("on_guild_leave", self.del_special_roles)
+        register_hook("on_guild_leave", self.remove_special_roles)
 
     def add_guild_settings(self, guild):
         logger.info(
@@ -177,7 +177,7 @@ class SettingsModel:
             None, self.sql.max_delete_messages
         )
 
-    def del_guild_settings(self, guild):
+    def remove_guild_settings(self, guild):
         logger.info(
             "Removing guild settings row for departing guild '%s' (%d)",
             guild.name,
@@ -265,7 +265,7 @@ class SettingsModel:
         self.sql.execute(ins)
         self.roles_cache[guild] = SpecialRoleStorage(guild, None, None, None, None)
 
-    def del_special_roles(self, guild):
+    def remove_special_roles(self, guild):
         logger.info(
             "Removing special roles row for new guild '%s' (%d)", guild.name, guild.id
         )


### PR DESCRIPTION
Fixes #41 
* Allows users to assign roles to themselves, with a wide range of aliases (`add`, `join`, etc)
* Allows moderators to make roles self-assignable (`joinable`/`unjoinable` or `canjoin`/`cannotjoin`)
* Ensures that, when added, roles do not grant any special permissions
* Persists role configuration to disk
* Changes are applies idempotently