### PR TITLE
Restrict channels for role command

### DIFF
--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -84,6 +84,8 @@ class SelfAssignableRoles:
     async def role_show(self, ctx):
         """ Shows all self-assignable roles. """
 
+        await self.check_channel(ctx)
+
         assignable_roles = sorted(
             self.bot.sql.roles.get_assignable_roles(ctx.guild), key=lambda r: r.name
         )
@@ -129,6 +131,7 @@ class SelfAssignableRoles:
     async def role_add(self, ctx, *roles: RoleConv):
         """ Joins the given self-assignable roles. """
 
+        await self.check_channel(ctx)
         self.check_roles(ctx, roles)
         await ctx.author.add_roles(
             *roles, reason="Adding self-assignable roles", atomic=True
@@ -141,6 +144,7 @@ class SelfAssignableRoles:
     async def role_remove(self, ctx, *roles: RoleConv):
         """ Leaves the given self-assignable roles. """
 
+        await self.check_channel(ctx)
         self.check_roles(ctx, roles)
         await ctx.author.remove_roles(
             *roles, reason="Removing self-assignable roles", atomic=True

--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -93,7 +93,10 @@ class SelfAssignableRoles:
             prefix = self.bot.prefix(ctx.guild)
             embed = discord.Embed(colour=discord.Colour.dark_purple())
             embed.set_author(name="No self-assignable roles")
-            embed.description = f"Moderators can use the `{prefix}role joinable/unjoinable` commands to change this list!"
+            embed.description = (
+                f"Moderators can use the `{prefix}role joinable/unjoinable` "
+                "commands to change this list!"
+            )
             await self.author_send(ctx, embed=embed)
             return
 

--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -91,8 +91,8 @@ class SelfAssignableRoles:
             prefix = self.bot.prefix(ctx.guild)
             embed = discord.Embed(colour=discord.Colour.dark_purple())
             embed.set_author(name="No self-assignable roles")
-            embed.description = f"Use the `{prefix}role joinable/unjoinable` commands to change this list!"
-            await ctx.send(embed=embed)
+            embed.description = f"Moderators can use the `{prefix}role joinable/unjoinable` commands to change this list!"
+            await self.author_send(ctx, embed=embed)
             return
 
         embed = discord.Embed(colour=discord.Colour.dark_teal())
@@ -103,7 +103,7 @@ class SelfAssignableRoles:
             descr.write(role.mention)
         embed.description = str(descr)
 
-        await ctx.send(embed=embed)
+        await self.author_send(ctx, embed=embed)
 
     def check_roles(self, ctx, roles):
         if not roles:
@@ -387,4 +387,4 @@ class SelfAssignableRoles:
                 "can be used anywhere."
             )
 
-        await ctx.send(embed=embed)
+        await self.author_send(ctx, embed=embed)

--- a/futaba/sql/models/roles.py
+++ b/futaba/sql/models/roles.py
@@ -132,6 +132,7 @@ class SelfAssignableRolesModel:
             self.tb_role_command_channels.c.guild_id == guild.id
         )
         self.sql.execute(delet)
+        self.channels_cache[guild].clear()
 
     def get_role_command_channels(self, guild):
         logger.info(
@@ -140,7 +141,7 @@ class SelfAssignableRolesModel:
             guild.id,
         )
 
-        if guild in self.channels_cache[guild]:
+        if guild in self.channels_cache:
             logger.debug("Found channels in cache, returning")
             return self.channels_cache[guild]
 

--- a/futaba/sql/models/roles.py
+++ b/futaba/sql/models/roles.py
@@ -100,6 +100,7 @@ class SelfAssignableRolesModel:
 
     def add_assignable_role(self, guild, role):
         logger.info("Adding assignable role for guild '%s' (%d)", guild.name, guild.id)
+        assert guild == role.guild
         ins = self.tb_assignable_roles.insert().values(
             guild_id=guild.id, role_id=role.id
         )
@@ -110,6 +111,7 @@ class SelfAssignableRolesModel:
         logger.info(
             "Removing assignable role for guild '%s' (%d)", guild.name, guild.id
         )
+        assert guild == role.guild
         delet = self.tb_assignable_roles.delete().where(
             and_(
                 self.tb_assignable_roles.c.guild_id == guild.id,


### PR DESCRIPTION
To prevent people from just hopping into #off-topic and spamming role joins without caring about the effect of the conversation they are derailing, shiro disabled role commands for everything but #bot.

This PR implements the same functionality, but in the futaba style. Meaning, it is completely configurable, durably persistent, and not tied to Programming specifically.