### PR TITLE
Upload all unexpected tracebacks to an error channel

### DIFF
--- a/futaba/client.py
+++ b/futaba/client.py
@@ -104,11 +104,9 @@ class Bot(commands.AutoShardedBot):
 
         # Get error channel
         if self.config.error_channel_id:
-            for channel in self.get_all_channels():
-                if isinstance(channel, discord.TextChannel):
-                    if channel.id == self.config.error_channel_id:
-                        self.error_channel = channel
-                        break
+            channel = self.get_channel(self.config.error_channel_id)
+            if isinstance(channel, discord.TextChannel):
+                self.error_channel = channel
 
         # Setup mandatory cogs
         self.add_cog(Journal(self))

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -45,13 +45,14 @@ logger = logging.getLogger(__name__)
 
 
 class Bot(commands.AutoShardedBot):
-    __slots__ = ("config", "start_time", "journal_cog", "sql")
+    __slots__ = ("config", "start_time", "journal_cog", "sql", "error_channel")
 
     def __init__(self, config: Configuration):
         self.config = config
         self.start_time = datetime.utcnow()
         self.journal_cog = None
         self.sql = SqlHandler(config.database_url)
+        self.error_channel = None
 
         super().__init__(
             command_prefix=self.my_command_prefix,
@@ -98,6 +99,14 @@ class Bot(commands.AutoShardedBot):
         After the bot has logged in and filled up its cache.
         Sets up the bot's state, loads cogs then prints a 'ready' message.
         """
+
+        # Get error channel
+        if self.config.error_channel_id:
+            for channel in self.get_all_channels():
+                if isinstance(channel, discord.TextChannel):
+                    if channel.id == self.config.error_channel_id:
+                        self.error_channel = channel
+                        break
 
         # Setup mandatory cogs
         self.add_cog(Journal(self))

--- a/futaba/cogs/info/alias.py
+++ b/futaba/cogs/info/alias.py
@@ -14,7 +14,6 @@
 Tracking for aliases of members, storing previous usernames, nicknames, and avatars.
 """
 
-import asyncio
 import logging
 import re
 from datetime import datetime

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -28,6 +28,7 @@ Configuration = namedtuple(
         "token",
         "owner_ids",
         "default_prefix",
+        "error_channel_id",
         "max_cleanup_messages",
         "anger_emoji_id",
         "python_emoji_id",
@@ -58,6 +59,11 @@ def load_config(path):
     config_bot = _get(config, "bot")
     token = _get(config_bot, "token", "bot")
     prefix = _get(config_bot, "prefix", "bot")
+
+    try:
+        error_channel_id = int(_get(config_bot, "error-channel-id", "bot"))
+    except ValueError:
+        raise InvalidConfigError("Channel IDs must be integers", config)
 
     try:
         owner_ids = [int(id) for id in _get(config_bot, "owners", "bot")]
@@ -93,6 +99,7 @@ def load_config(path):
         token=token,
         owner_ids=owner_ids,
         default_prefix=prefix,
+        error_channel_id=error_channel_id,
         max_cleanup_messages=max_cleanup_messages,
         anger_emoji_id=anger_emoji_id,
         python_emoji_id=python_emoji_id,

--- a/futaba/str_builder.py
+++ b/futaba/str_builder.py
@@ -10,7 +10,7 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-from io import StringIO
+from io import BytesIO, StringIO
 
 __all__ = ["StringBuilder"]
 
@@ -39,8 +39,17 @@ class StringBuilder:
         self.buffer.seek(0)
         self.buffer.truncate(0)
 
+    def bytes(self):
+        return str(self).encode("utf-8")
+
+    def bytes_io(self):
+        return BytesIO(self.bytes())
+
     def __str__(self):
         return self.buffer.getvalue()
+
+    def __repr__(self):
+        return f"<StringBuilder ({len(self)} chars) at 0x{id(self):08x}>"
 
     def __bool__(self):
         return bool(len(self))

--- a/misc/config.toml
+++ b/misc/config.toml
@@ -9,6 +9,10 @@ owners = ["98633956773093376", "130012001236811776"]
 # Default bot command prefix
 prefix = "!"
 
+# The tracebacks of any unexpected errors are uploaded to this file.
+# Set to "0" to disable
+error-channel-id = "488543452305555456"
+
 [moderation]
 # Maximum number of messages that may be specified
 # when doing a bulk message cleanup


### PR DESCRIPTION
Fixes #101 

Allows the configuration of a traceback channel in the config file. If set, all unexpected errors are uploaded as a file, complete with information about the environment the command was run in. This will allow the bot to be debugged even if you weren't present for the error or it occurred in a different guild.

This option is owner-only/config-level to prevent leaking of information from other guilds.

[Example output log](https://cdn.discordapp.com/attachments/488543452305555456/504526558749392897/futaba-traceback-1540358905.log)