### PR TITLE
Full message content

### DIFF
--- a/JOURNAL_PATHS.md
+++ b/JOURNAL_PATHS.md
@@ -83,10 +83,13 @@ All attributes (will) have `member: discord.Member`, `reason: Optional[str]`, `c
 * `/tracking/typing` - Typing event. Attributes: `channel: discord.Messageable`, `user: discord.User`, `when: datetime`
 * `/tracking/message/new` - A new message was sent. Attributes: `message: discord.Message`
 * `/tracking/jump/message/new` - Jump link for new message. Same attributes.
+* `/tracking/full/message/new` - Full message content for new message, with jump link. Same attributes.
 * `/tracking/message/edit` - A message was edited. Attributes: `before: discord.Message`, `after: discord.Message`
 * `/tracking/jump/message/edit` - Jump link for edited message. Same attributes.
+* `/tracking/full/message/edit` - Full message content for edited message, with jump link. Same attributes.
 * `/tracking/message/delete` - A message was deleted. Attributes: `message: discord.Message`, `cause: MessageDeletionReason`
 * `/tracking/jump/message/delete` - Jump link for deleted message. Same attributes.
+* `/tracking/full/message/delete` - Full message content for deleted message, with jump link. Same attributes.
 * `/tracking/reaction/add` - A reaction was added to a message. Attributes: `reaction: discord.Reaction`, `user: discord.User`
 * `/tracking/jump/reaction/add` - Jump link for reacted message. Attributes: `message: discord.Message`
 * `/tracking/reaction/remove` - A reaction was removed to a message. Attributes: `reaction: discord.Reaction`, `user: discord.User`

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -117,16 +117,18 @@ class Tracker:
     @staticmethod
     def build_embed(message):
         embed = discord.Embed(description=message.content)
-        embed.set_author(name=message.author.display_name, icon_url=message.author.avatar_url)
+        embed.set_author(
+            name=message.author.display_name, icon_url=message.author.avatar_url
+        )
         embed.timestamp = message.edited_at or message.created_at
 
         if message.attachments:
             embed.add_field(
-                name='Attachments',
-                value='\n'.join(attach.url for attach in message.attachments)
+                name="Attachments",
+                value="\n".join(attach.url for attach in message.attachments),
             )
         if message.embeds:
-            embed.add_field(name='Embeds', value=str(len(message.embeds)))
+            embed.add_field(name="Embeds", value=str(len(message.embeds)))
 
         return embed
 

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -60,6 +60,7 @@ class Tracker:
         "journal",
         "new_messages",
         "edited_messages",
+        "deleted_messages",
         "members_joined",
         "members_left",
         "reactions",
@@ -71,6 +72,7 @@ class Tracker:
         self.journal = bot.get_broadcaster("/tracking")
         self.new_messages = deque(maxlen=20)
         self.edited_messages = deque(maxlen=20)
+        self.deleted_messages = deque(maxlen=20)
         self.members_joined = deque(maxlen=20)
         self.members_left = deque(maxlen=20)
         self.reactions = deque(maxlen=20)
@@ -236,6 +238,11 @@ class Tracker:
         )
 
     async def on_message_delete(self, message):
+        if message in self.deleted_messages:
+            return
+        else:
+            self.deleted_messages.append(message)
+
         if message.guild is None:
             return
 


### PR DESCRIPTION
Fixes #136 

Adds a new set of journal events, `/tracking/full/message/[new|edit|delete]` which add an embed with the message in question.