### PR TITLE
Add command for querying recent journal events

### DIFF
--- a/futaba/__init__.py
+++ b/futaba/__init__.py
@@ -18,6 +18,7 @@ from . import (
     client,
     config,
     converters,
+    dict_convert,
     download,
     emojis,
     enums,

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -16,6 +16,7 @@ of messages to different logging channels.
 """
 
 import asyncio
+import json
 import logging
 import traceback
 from itertools import islice
@@ -294,26 +295,11 @@ class Journal(AbstractCog):
             "", ctx.guild, content, **journal_attributes
         )
 
-    @log.command(name="find", aliases=["search", "query", "recent", "history"])
-    @commands.guild_only()
-    @permissions.check_mod()
-    async def log_find(self, ctx, *, condition: str = None):
-        """
-        List previous journal events that match the given conditions.
-        The condition is a Python expression with no variables but
-        the following attributes:
-
-        path: str
-        ppath: PurePath
-        guild: discord.Guild
-        content: str
-        attributes: dict
-        """
-
+    def log_filter(self, guild, condition, max_items):
         logging.info(
             "Finding journal entries in guild '%s' (%d) matching: %s",
-            ctx.guild.name,
-            ctx.guild.id,
+            guild.name,
+            guild.id,
             condition or "(none)",
         )
 
@@ -321,14 +307,14 @@ class Journal(AbstractCog):
             return {
                 "path": str(event.path),
                 "ppath": event.path,
-                "guild": ctx.guild,
+                "guild": guild,
                 "content": event.content,
                 "attributes": event.attributes,
             }
 
         events = reversed(self.journal.history)
-        events = filter(lambda evt: evt.guild == ctx.guild, events)
-        events = islice(events, 10)
+        events = filter(lambda evt: evt.guild == guild, events)
+        events = islice(events, max_items)
 
         if condition is None:
             matched = events
@@ -345,37 +331,54 @@ class Journal(AbstractCog):
                 embed.description = f"```py\n{trace}\n```"
                 raise CommandFailed(embed=embed)
 
-            matched = []
-            sent_error = False
-            for event in tuple(events):
-                try:
-                    if eval(condition, create_scope(event)):
-                        matched.append(event)
-                except Exception as error:
-                    logger.info(
-                        "Runtime error while evaluating condition", exc_info=error
-                    )
-                    if sent_error:
-                        continue
+        matched = []
+        error_embeds = []
+        for event in tuple(events):
+            try:
+                # Limited eval for journal filter evaluation
+                # pylint: disable=eval-used
+                if eval(condition, create_scope(event)):
+                    matched.append(event)
+            except Exception as error:
+                logger.info("Runtime error while evaluating condition", exc_info=error)
 
-                    embed = discord.Embed(colour=discord.Colour.red())
-                    embed.set_author(name="Runtime error checking condition")
-                    trace = "\n".join(
-                        traceback.format_exception(
-                            type(error), error, error.__traceback__
-                        )
-                    )
-                    embed.description = f"```py\n{trace}\n```"
-                    await ctx.send(embed=embed)
-                    sent_error = True
+                embed = discord.Embed(colour=discord.Colour.red())
+                embed.set_author(name="Runtime error checking condition")
+                trace = "\n".join(
+                    traceback.format_exception(type(error), error, error.__traceback__)
+                )
+                embed.description = f"```py\n{trace}\n```"
+                error_embeds.append(embed)
+        return matched, error_embeds
 
-        if matched:
+    @log.command(name="find", aliases=["search", "query", "recent", "history"])
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def log_find(self, ctx, *, condition: str = None):
+        """
+        List previous journal events that match the given conditions.
+        The condition is a Python expression with no variables but
+        the following attributes:
+
+        path: str
+        ppath: PurePath
+        guild: discord.Guild
+        content: str
+        attributes: dict
+        """
+
+        events, error_embeds = self.log_filter(ctx.guild, condition, 10)
+
+        if error_embeds:
+            await ctx.send(embed=error_embeds[0])
+
+        if events:
             embed = discord.Embed(colour=discord.Colour.dark_teal())
             embed.set_author(name="Matching journal events")
             descr = StringBuilder()
 
             embeds = []
-            for event in matched:
+            for event in events:
                 descr.writeln(f"Path: `{event.path}`, Content: {event.content}")
                 descr.writeln(f"Attributes: ```py\n{pformat(event.attributes)}\n```\n")
                 if len(descr) > 1400:
@@ -393,3 +396,36 @@ class Journal(AbstractCog):
         for i, embed in enumerate(embeds):
             embed.set_footer(text=f"Page {i + 1}/{len(embeds)}")
             await ctx.send(embed=embed)
+
+    @log.command(name="dump", aliases=["jsondump", "recentdump", "historydump"])
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def log_dump(self, ctx, *, condition: str = None):
+        """
+        Dump previous journal events that match the given conditions to JSON.
+        The condition is a Python expression with no variables but
+        the following attributes:
+
+        path: str
+        ppath: PurePath
+        guild: discord.Guild
+        content: str
+        attributes: dict
+        """
+
+        events, error_embeds = self.log_filter(ctx.guild, condition, 50)
+
+        if error_embeds:
+            await ctx.send(embed=error_embeds[0])
+
+        buffer = StringBuilder()
+        obj = [event.to_dict() for event in reversed(events)]
+        json.dump(obj, buffer, ensure_ascii=True)
+        file = discord.File(buffer.bytes_io(), filename="journal-events.json")
+
+        embed = discord.Embed(colour=discord.Colour.dark_teal())
+        embed.description = (
+            "Uploaded journal events as JSON, see attached file. "
+            "\N{WHITE UP POINTING BACKHAND INDEX}"
+        )
+        await ctx.send(embed=embed, file=file)

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -21,10 +21,11 @@ import discord
 from discord.ext import commands
 
 from futaba import permissions
+from futaba.dict_convert import message_dict
 from futaba.exceptions import CommandFailed
 from futaba.str_builder import StringBuilder
 from futaba.unicode import normalize_caseless
-from futaba.utils import escape_backticks, message_to_dict, user_discrim
+from futaba.utils import escape_backticks, user_discrim
 from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
@@ -85,7 +86,7 @@ class Cleanup(AbstractCog):
     @staticmethod
     def dump_messages(messages):
         buffer = StringBuilder()
-        obj = list(map(message_to_dict, reversed(messages)))
+        obj = list(map(message_dict, reversed(messages)))
         json.dump(obj, buffer, ensure_ascii=True)
         return obj, discord.File(buffer.bytes_io(), filename="deleted-messages.json")
 

--- a/futaba/dict_convert.py
+++ b/futaba/dict_convert.py
@@ -1,0 +1,153 @@
+#
+# dict_convert.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+""" Converts discord objects to JSON-safe dictionaries. """
+
+import discord
+
+from futaba.utils import map_or
+
+__all__ = [
+    "named_dict",
+    "user_like_dict",
+    "user_dict",
+    "member_dict",
+    "role_dict",
+    "attachment_dict",
+    "emoji_dict",
+    "message_dict",
+    "to_dict",
+]
+
+
+def named_dict(obj):
+    return {"id": str(obj.id), "name": obj.name}
+
+
+def user_like_dict(user):
+    return {
+        "id": str(user.id),
+        "name": user.name,
+        "nick": getattr(user, "nick", None),
+        "discriminator": user.discriminator,
+    }
+
+
+def user_dict(user):
+    return {
+        "id": user.id,
+        "name": user.name,
+        "discriminator": user.discriminator,
+        "avatar": user.avatar,
+        "bot": user.bot,
+    }
+
+
+def member_dict(member):
+    return {
+        "id": member.id,
+        "name": member.name,
+        "discriminator": member.discriminator,
+        "nick": member.nick,
+        "avatar": member.avatar,
+        "bot": member.bot,
+        "joined_at": member.joined_at.isoformat(),
+        "status": str(member.status),
+    }
+
+
+def role_dict(role):
+    return {
+        "id": role.id,
+        "name": role.name,
+        "permissions": role.permissions.value,
+        "colour": role.colour.to_rgb(),
+        "hoist": role.hoist,
+        "position": role.position,
+        "managed": role.managed,
+        "mentionable": role.mentionable,
+    }
+
+
+def attachment_dict(attach):
+    return {
+        "id": str(attach.id),
+        "size": attach.size,
+        "height": attach.height,
+        "width": attach.width,
+        "filename": attach.filename,
+        "url": attach.url,
+        "proxy_url": attach.proxy_url,
+    }
+
+
+def emoji_dict(emoji):
+    if isinstance(emoji, str):
+        return emoji
+    else:
+        return {
+            "id": str(emoji.id),
+            "name": emoji.name,
+            "animated": emoji.animated,
+            "managed": getattr(emoji, "managed", False),
+            "guild_id": map_or(str, getattr(emoji, "guild_id", None)),
+            "url": emoji.url,
+        }
+
+
+def reaction_dict(react):
+    return {
+        "emoji": emoji_dict(react.emoji),
+        "count": react.count,
+        "message_id": str(react.message.id),
+    }
+
+
+def message_dict(message: discord.Message):
+    return {
+        "id": str(message.id),
+        "tts": message.tts,
+        "type": message.type.name,
+        "author": user_dict(message.author),
+        "content": message.content or message.system_content,
+        "embeds": [embed.to_dict() for embed in message.embeds],
+        "channel": named_dict(message.channel),
+        "mention_everyone": message.mention_everyone,
+        "user_mentions": [user_dict(user) for user in message.mentions],
+        "channel_mentions": [named_dict(chan) for chan in message.channel_mentions],
+        "role_mentions": [named_dict(role) for role in message.role_mentions],
+        "pinned": message.pinned,
+        "webhook_id": map_or(str, message.webhook_id),
+        "attachments": [attachment_dict(attach) for attach in message.attachments],
+        "reactions": [reaction_dict(react) for react in message.reactions],
+        "activity": message.activity,
+        "application": message.application,
+        "guild_id": map_or(lambda g: str(g.id), message.guild),
+        "edited_at": map_or(str, message.edited_at),
+    }
+
+
+def to_dict(obj):
+    if isinstance(obj, discord.User):
+        return user_dict(obj)
+    elif isinstance(obj, discord.Member):
+        return member_dict(obj)
+    elif isinstance(obj, discord.Role):
+        return role_dict(obj)
+    elif isinstance(obj, discord.Attachment):
+        return attachment_dict(obj)
+    elif isinstance(obj, (discord.Emoji, discord.PartialEmoji)):
+        return emoji_dict(obj)
+    elif isinstance(obj, discord.Message):
+        return message_dict(obj)
+    else:
+        return obj

--- a/futaba/dict_convert.py
+++ b/futaba/dict_convert.py
@@ -132,7 +132,7 @@ def message_dict(message: discord.Message):
         "activity": message.activity,
         "application": message.application,
         "guild_id": map_or(lambda g: str(g.id), message.guild),
-        "edited_at": map_or(str, message.edited_at),
+        "edited_at": map_or(lambda d: d.isoformat(), message.edited_at),
     }
 
 
@@ -149,5 +149,7 @@ def to_dict(obj):
         return emoji_dict(obj)
     elif isinstance(obj, discord.Message):
         return message_dict(obj)
+    elif isinstance(obj, discord.Embed):
+        return obj.to_dict()
     else:
         return obj

--- a/futaba/journal/__init__.py
+++ b/futaba/journal/__init__.py
@@ -17,6 +17,7 @@ Broadcaster and Listener classes that rely on it.
 """
 
 from .broadcaster import Broadcaster
+from .event import JournalEvent
 from .impl import ChannelOutputListener, LoggingOutputListener, ModerationListener
 from .listener import Listener
 from .router import Router

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -41,5 +41,7 @@ class Broadcaster:
             content,
             ", ".join(attributes.keys()) or "(none)",
         )
-        event = JournalEvent(path=path, guild=guild, content=content, attributes=attributes)
+        event = JournalEvent(
+            path=path, guild=guild, content=content, attributes=attributes
+        )
         self.router.queue.put_nowait(event)

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -45,3 +45,7 @@ class Broadcaster:
             path=path, guild=guild, content=content, attributes=attributes
         )
         self.router.queue.put_nowait(event)
+
+    @property
+    def history(self):
+        return self.router.history

--- a/futaba/journal/broadcaster.py
+++ b/futaba/journal/broadcaster.py
@@ -13,6 +13,8 @@
 import logging
 from pathlib import PurePath
 
+from .event import JournalEvent
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["Broadcaster"]
@@ -39,4 +41,5 @@ class Broadcaster:
             content,
             ", ".join(attributes.keys()) or "(none)",
         )
-        self.router.queue.put_nowait((path, guild, content, attributes))
+        event = JournalEvent(path=path, guild=guild, content=content, attributes=attributes)
+        self.router.queue.put_nowait(event)

--- a/futaba/journal/event.py
+++ b/futaba/journal/event.py
@@ -12,4 +12,4 @@
 
 from collections import namedtuple
 
-JournalEvent = namedtuple('JournalEvent', ('path', 'guild', 'content', 'attributes'))
+JournalEvent = namedtuple("JournalEvent", ("path", "guild", "content", "attributes"))

--- a/futaba/journal/event.py
+++ b/futaba/journal/event.py
@@ -10,6 +10,24 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-from collections import namedtuple
+from futaba.dict_convert import named_dict, to_dict
 
-JournalEvent = namedtuple("JournalEvent", ("path", "guild", "content", "attributes"))
+
+class JournalEvent:
+    __slots__ = ("path", "guild", "content", "attributes")
+
+    def __init__(self, *, path, guild, content, attributes):
+        self.path = path
+        self.guild = guild
+        self.content = content
+        self.attributes = attributes
+
+    def to_dict(self):
+        return {
+            "path": self.path,
+            "guild": named_dict(self.guild),
+            "content": self.content,
+            "attributes": {
+                key: to_dict(value) for key, value in self.attributes.items()
+            },
+        }

--- a/futaba/journal/event.py
+++ b/futaba/journal/event.py
@@ -1,0 +1,15 @@
+#
+# journal/event.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+from collections import namedtuple
+
+JournalEvent = namedtuple('JournalEvent', ('path', 'guild', 'content', 'attributes'))

--- a/futaba/journal/event.py
+++ b/futaba/journal/event.py
@@ -24,7 +24,7 @@ class JournalEvent:
 
     def to_dict(self):
         return {
-            "path": self.path,
+            "path": str(self.path),
             "guild": named_dict(self.guild),
             "content": self.content,
             "attributes": {

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -27,12 +27,12 @@ __all__ = ["Router"]
 
 
 class Router:
-    __slots__ = ("paths", "queue", "events")
+    __slots__ = ("paths", "queue", "history")
 
     def __init__(self):
         self.paths = defaultdict(list)
         self.queue = asyncio.Queue()
-        self.events = deque(maxlen=1024)
+        self.history = deque(maxlen=1024)
 
     def start(self, eventloop):
         logger.info("Start journal event processing task")
@@ -84,4 +84,4 @@ class Router:
             responses.clear()
 
             # Append to event list
-            self.events.append(event)
+            self.history.append(event)

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -12,7 +12,7 @@
 
 import asyncio
 import logging
-from collections import defaultdict
+from collections import defaultdict, deque
 from itertools import chain
 from pathlib import PurePath
 
@@ -27,11 +27,12 @@ __all__ = ["Router"]
 
 
 class Router:
-    __slots__ = ("paths", "queue")
+    __slots__ = ("paths", "queue", 'events')
 
     def __init__(self):
         self.paths = defaultdict(list)
         self.queue = asyncio.Queue()
+        self.events = deque(maxlen=1024)
 
     def start(self, eventloop):
         logger.info("Start journal event processing task")
@@ -80,4 +81,5 @@ class Router:
                 logger.error("Error while running journal handlers", exc_info=error)
             responses.clear()
 
-            events.clear()
+            # Append to event list
+            self.events.append(event)

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -18,7 +18,6 @@ from pathlib import PurePath
 
 import discord
 
-from .event import JournalEvent
 from .process import process_content
 
 logger = logging.getLogger(__name__)

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -27,7 +27,7 @@ __all__ = ["Router"]
 
 
 class Router:
-    __slots__ = ("paths", "queue", 'events')
+    __slots__ = ("paths", "queue", "events")
 
     def __init__(self):
         self.paths = defaultdict(list)
@@ -71,7 +71,9 @@ class Router:
                 for listener in self.paths[path]:
                     if listener.check(path, event.guild, content, event.attributes):
                         responses.append(
-                            listener.handle(event.path, event.guild, content, event.attributes)
+                            listener.handle(
+                                event.path, event.guild, content, event.attributes
+                            )
                         )
 
             # Run all the event handlers

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -18,6 +18,7 @@ from pathlib import PurePath
 
 import discord
 
+from .event import JournalEvent
 from .process import process_content
 
 logger = logging.getLogger(__name__)
@@ -55,27 +56,28 @@ class Router:
         self.paths[listener.path].remove(listener)
 
     async def handle_events(self):
-        events = []
+        responses = []
 
         while True:
             logger.debug("Waiting for new journal event")
-            event_path, guild, content, attributes = await self.queue.get()
-            logger.debug("Got journal event on %s: '%s'", event_path, content)
-            content = process_content(content, attributes)
-            logger.debug("Journal content after processing: '%s'", content)
+            event = await self.queue.get()
+            logger.debug("Got journal event on %s: '%s'", event.path, event.content)
+            content = process_content(event.content, event.attributes)
+            logger.debug("Journal content after processing: '%s'", event.content)
 
             # Add events for this path
-            for path in chain((event_path,), event_path.parents):
+            for path in chain((event.path,), event.path.parents):
                 for listener in self.paths[path]:
-                    if listener.check(path, guild, content, attributes):
-                        events.append(
-                            listener.handle(event_path, guild, content, attributes)
+                    if listener.check(path, event.guild, content, event.attributes):
+                        responses.append(
+                            listener.handle(event.path, event.guild, content, event.attributes)
                         )
 
             # Run all the event handlers
             try:
-                await asyncio.gather(*events)
+                await asyncio.gather(*responses)
             except Exception as error:
                 logger.error("Error while running journal handlers", exc_info=error)
+            responses.clear()
 
             events.clear()

--- a/futaba/utils.py
+++ b/futaba/utils.py
@@ -16,8 +16,6 @@ import subprocess
 from datetime import datetime
 from itertools import zip_longest
 
-import discord
-
 from futaba.str_builder import StringBuilder
 
 logger = logging.getLogger(__name__)
@@ -32,7 +30,6 @@ __all__ = [
     "async_partial",
     "map_or",
     "if_not_null",
-    "message_to_dict",
     "first",
     "chunks",
     "lowerbool",
@@ -151,71 +148,6 @@ def if_not_null(obj, alt):
             return alt
 
     return obj
-
-
-def message_to_dict(message: discord.Message):
-    """ Converts a message into a JSON-safe python dictionary. """
-
-    def user_dict(user):
-        return {
-            "id": str(user.id),
-            "name": user.name,
-            "nick": getattr(user, "nick", None),
-            "discriminator": user.discriminator,
-        }
-
-    def named_dict(obj):
-        return {"id": str(obj.id), "name": obj.name}
-
-    def attachment_dict(attach):
-        return {
-            "id": str(attach.id),
-            "size": attach.size,
-            "height": attach.height,
-            "width": attach.width,
-            "filename": attach.filename,
-            "url": attach.url,
-            "proxy_url": attach.proxy_url,
-        }
-
-    def emoji_dict(emoji):
-        if isinstance(emoji, str):
-            return emoji
-        else:
-            return {
-                "id": str(emoji.id),
-                "name": emoji.name,
-                "animated": emoji.animated,
-                "managed": emoji.managed,
-                "guild_id": str(emoji.guild_id),
-                "url": emoji.url,
-            }
-
-    def reaction_dict(react):
-        return {"emoji": emoji_dict(react.emoji), "count": react.count}
-
-    # Build the final dictionary
-    return {
-        "id": str(message.id),
-        "tts": message.tts,
-        "type": message.type.name,
-        "author": user_dict(message.author),
-        "content": message.content or message.system_content,
-        "embeds": [embed.to_dict() for embed in message.embeds],
-        "channel": named_dict(message.channel),
-        "mention_everyone": message.mention_everyone,
-        "user_mentions": [user_dict(user) for user in message.mentions],
-        "channel_mentions": [named_dict(chan) for chan in message.channel_mentions],
-        "role_mentions": [named_dict(role) for role in message.role_mentions],
-        "pinned": message.pinned,
-        "webhook_id": map_or(str, message.webhook_id),
-        "attachments": [attachment_dict(attach) for attach in message.attachments],
-        "reactions": [reaction_dict(react) for react in message.reactions],
-        "activity": message.activity,
-        "application": message.application,
-        "guild_id": map_or(lambda g: str(g.id), message.guild),
-        "edited_at": map_or(str, message.edited_at),
-    }
 
 
 def first(iterable, default=None):


### PR DESCRIPTION
Fixes #138 

Adds `!log find`, which displays recent events. If the argument is passed, it is interpreted as a python expression determining if the condition is true or not. No builtins or variables are permitted. Only moderators and above may use it, as it can leak information.