### PR TITLE
Requiring passing a jail duration

### DIFF
--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -174,9 +174,7 @@ class Moderation:
     @commands.command(name="jail", aliases=["dunce"])
     @commands.guild_only()
     @permissions.check_mod()
-    async def jail(
-        self, ctx, member: MemberConv, minutes: int, *, reason: str = None
-    ):
+    async def jail(self, ctx, member: MemberConv, minutes: int, *, reason: str = None):
         """
         Jails the user.
         Requires a jail role to be configured.

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -175,7 +175,7 @@ class Moderation:
     @commands.guild_only()
     @permissions.check_mod()
     async def jail(
-        self, ctx, member: MemberConv, minutes: int = 0, *, reason: str = None
+        self, ctx, member: MemberConv, minutes: int = 480, *, reason: str = None
     ):
         """
         Jails the user.

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -175,12 +175,12 @@ class Moderation:
     @commands.guild_only()
     @permissions.check_mod()
     async def jail(
-        self, ctx, member: MemberConv, minutes: int = 480, *, reason: str = None
+        self, ctx, member: MemberConv, minutes: int, *, reason: str = None
     ):
         """
         Jails the user.
         Requires a jail role to be configured.
-        Set 'minutes' to 0 to jail without a timer.
+        The minutes parameter must be set to a positive number.
         """
 
         roles = self.bot.sql.settings.get_special_roles(ctx.guild)


### PR DESCRIPTION
Change the default jail time to 480 minutes (8 hours) as per @robstolarz request
![image](https://user-images.githubusercontent.com/18365785/47797937-41a72d80-dd1f-11e8-878b-4e8473bef8be.png)
