### PR TITLE
Improvements to moderation warnings

### DIFF
--- a/futaba/cogs/moderation/manual_mod_action_warn.py
+++ b/futaba/cogs/moderation/manual_mod_action_warn.py
@@ -66,16 +66,20 @@ class ManualModActionWarn:
             ManualModActionType.SPECIAL_ROLE_MEMBER,
         ):
             role = kwargs["role"]
-
-            message = f'You manually added or removed the {action.value} role: "{role.name}", which normally should be managed automatically.'
+            response = (
+                f"You manually added or removed the {action.value} role '{role.mention}'"
+                ", which normally should be managed automatically."
+            )
         elif action in (
             ManualModActionType.SPECIAL_ROLE_MUTE,
             ManualModActionType.SPECIAL_ROLE_JAIL,
         ):
             role = kwargs["role"]
-
             command = manual_mod_action_command_map[action].format(prefix=prefix)
-            message = f'You manually added or removed {action.value} role: "{role.name}". In the future, use the command {command}'
+            response = (
+                f"You manually added or removed the {action.value} role '{role.mention}'"
+                f". In the future, you should use the command `{command}` instead."
+            )
         else:
             command = manual_mod_action_command_map[action].format(prefix=prefix)
 
@@ -86,9 +90,12 @@ class ManualModActionWarn:
                 "kicked" if action is ManualModActionType.KICK_MEMBER else "banned"
             )
 
-            message = f"You manually {action_name} {target_member.display_name} ({target_member}){reason_message}. In the future, use the command {command}"
+            response = (
+                f"You manually {action_name} {target_member.mention}{reason_message}. "
+                f"In the future, you should use the command `{command}` instead."
+            )
 
-        await moderator.send(message)
+        await moderator.send(content=response)
 
     async def find_manually_updated_roles(self, member, roles):
         """Finds which roles were manually updated by a moderator.

--- a/futaba/cogs/moderation/manual_mod_action_warn.py
+++ b/futaba/cogs/moderation/manual_mod_action_warn.py
@@ -14,7 +14,7 @@
 Cog to warn when a mod action is done manually, instead of through the bot.
 """
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 
 from discord import AuditLogAction
@@ -106,6 +106,7 @@ class ManualModActionWarn:
 
         roles = set(roles)
         updated_roles = []
+        utc_now = datetime.utcnow()
 
         async for entry in member.guild.audit_logs(
             limit=20, action=AuditLogAction.member_role_update
@@ -114,6 +115,9 @@ class ManualModActionWarn:
                 continue
 
             if entry.user == self.bot.user:
+                continue
+
+            if (utc_now - entry.created_at) >= timedelta(seconds=5):
                 continue
 
             roles_updated_here = roles & (

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -420,7 +420,10 @@ class Settings:
             prefix = self.bot.prefix(ctx.guild)
             embed = discord.Embed(colour=discord.Colour.dark_purple())
             embed.set_author(name="No blacklist entries")
-            embed.description = f"Moderators can use the `{prefix}trackerblacklist add/remove` commands to change this list!"
+            embed.description = (
+                f"Moderators can use the `{prefix}trackerblacklist add/remove` "
+                "commands to change this list!"
+            )
             await ctx.send(embed=embed)
             return
 

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -323,7 +323,7 @@ class SettingsModel:
         self.guild_settings_cache[guild].max_delete_messages = max_delete_messages
 
     def get_warn_manual_mod_action(self, guild):
-        logger.info(
+        logger.debug(
             "Getting warn manual mod action flag for guild '%s' (%d)",
             guild.name,
             guild.id,


### PR DESCRIPTION
A member joining or leaving a guild could trigger "you've performed a manual action" PMs because it would find an older entry and assume it applied in this case. I added a check to ensure that the time between the audit entry and the present are not more than 5 seconds apart.

Also various other changes cherry-picked from my development branch.