### PR TITLE
Add command to see which roles will be reapplied

### DIFF
--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -89,6 +89,7 @@ class Welcome:
         self.recently_joined = deque(maxlen=5)
 
         self.add_listener()
+        bot.add_cog(self.roles)
 
         for guild in bot.guilds:
             bot.sql.welcome.get_welcome(guild)

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -135,7 +135,6 @@ class Welcome:
             member.guild.id,
         )
 
-        print(f"$$ {self.bot.cogs}")
         if "RoleReapplication" in self.bot.cogs:
             if self.bot.sql.settings.get_reapply_roles(member.guild):
                 roles = self.bot.sql.roles.get_member_roles(member)

--- a/futaba/cogs/welcome/role_reapplication.py
+++ b/futaba/cogs/welcome/role_reapplication.py
@@ -15,13 +15,20 @@ Handling to reapply roles when the member rejoins the guild.
 """
 
 import logging
+from collections import namedtuple
 
+import discord
+from discord.ext import commands
+
+from futaba.converters import UserConv
 from futaba.str_builder import StringBuilder
 from futaba.utils import user_discrim
 
 logger = logging.getLogger(__name__)
+FakeMember = namedtuple('FakeMember', ('name', 'id', 'guild'))
 
 __all__ = ["RoleReapplication"]
+
 
 
 class RoleReapplication:
@@ -71,14 +78,40 @@ class RoleReapplication:
 
         return can_reapply
 
-    async def reapply_roles(self, member):
+    def get_roles_to_reapply(self, member):
         roles = self.bot.sql.roles.get_saved_roles(member)
         if not roles:
             logger.debug("No roles to reapply, user is new")
-            return
+            return None
 
         can_reapply = self.get_reapply_roles(member.guild)
-        roles = tuple(filter(lambda r: r in can_reapply, roles))
+        return list(filter(lambda r: r in can_reapply, roles))
+
+    @commands.guild_only()
+    @commands.command(name="savedroles", aliases=["saveroles", "userroles", "uroles"])
+    async def saved_roles(self, ctx, user: UserConv = None):
+        """ Returns all roles that would be reapplied when a given user rejoins. """
+
+        if user is None:
+            member = ctx.author
+        else:
+            member = FakeMember(id=user.id, name=user.name, guild=ctx.guild)
+
+        roles = self.get_roles_to_reapply(member)
+        if roles:
+            roles.sort(key=lambda r: r.position, reverse=True)
+            embed = discord.Embed(colour=discord.Colour.dark_teal())
+            embed.title = "\N{MILITARY MEDAL} Roles which would be applied on join"
+            embed.description = " ".join(role.mention for role in roles)
+        else:
+            embed = discord.Embed(colour=discord.Colour.dark_purple())
+            embed.description = "No roles are saved for this user."
+        await ctx.send(embed=embed)
+
+    async def reapply_roles(self, member):
+        roles = self.get_roles_to_reapply(member)
+        if roles is None:
+            return
 
         logger.info(
             "Reapplying roles to member '%s' (%d): [%s]",

--- a/futaba/cogs/welcome/role_reapplication.py
+++ b/futaba/cogs/welcome/role_reapplication.py
@@ -93,18 +93,23 @@ class RoleReapplication:
 
         if user is None:
             member = ctx.author
+            mention = ctx.author.mention
         else:
             member = FakeMember(id=user.id, name=user.name, guild=ctx.guild)
+            mention = user.mention
 
         roles = self.get_roles_to_reapply(member)
         if roles:
             roles.sort(key=lambda r: r.position, reverse=True)
+            role_list = " ".join(role.mention for role in roles)
+            sep = "\n\n" if len(roles) > 3 else " "
+
             embed = discord.Embed(colour=discord.Colour.dark_teal())
             embed.title = "\N{MILITARY MEDAL} Roles which would be applied on join"
-            embed.description = " ".join(role.mention for role in roles)
+            embed.description = f"{mention}:{sep}{role_list}"
         else:
             embed = discord.Embed(colour=discord.Colour.dark_purple())
-            embed.description = "No roles are saved for this user."
+            embed.description = f"No roles are saved for {mention}."
         await ctx.send(embed=embed)
 
     async def reapply_roles(self, member):

--- a/futaba/cogs/welcome/role_reapplication.py
+++ b/futaba/cogs/welcome/role_reapplication.py
@@ -25,10 +25,9 @@ from futaba.str_builder import StringBuilder
 from futaba.utils import user_discrim
 
 logger = logging.getLogger(__name__)
-FakeMember = namedtuple('FakeMember', ('name', 'id', 'guild'))
+FakeMember = namedtuple("FakeMember", ("name", "id", "guild"))
 
 __all__ = ["RoleReapplication"]
-
 
 
 class RoleReapplication:


### PR DESCRIPTION
Adds `!savedroles` or `!uroles` which lists all roles that will be automatically reapplied to the given user if they were to rejoin.

![example of command usage](https://user-images.githubusercontent.com/8848022/48726478-79f2ab00-ebfd-11e8-950b-efb4ce1fe641.png)
