### PR TITLE
Role reapplication runtime fixes

### DIFF
--- a/futaba/__init__.py
+++ b/futaba/__init__.py
@@ -32,4 +32,4 @@ from . import (
     utils,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -415,7 +415,7 @@ class Bot(commands.AutoShardedBot):
             full_tb.writeln(f"Roles:")
             for role in ctx.author.roles:
                 perms = role.permissions.value
-                full_tb.writeln(f"  {role.name} ({role.id}): ")
+                full_tb.writeln(f"  {role.name} ({role.id}):")
                 full_tb.writeln(f"    created at: {role.created_at}")
                 full_tb.writeln(f"    members: {len(role.members)}")
                 full_tb.writeln(f"    permissions: 0x{perms:016x}")

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -425,5 +425,7 @@ class Bot(commands.AutoShardedBot):
         full_tb.writeln(trace)
 
         # Upload traceback to error channel
+        unix_time = int(datetime.now().timestamp())
+        filename = f"futaba-extended-traceback-{unix_time}.log"
         file = discord.File(fp=full_tb.bytes_io(), filename=filename)
         await self.error_channel.send(file=file)

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -500,7 +500,7 @@ class Settings:
 
         if value is None:
             # Get reapplication roles
-            reapply = self.bot.sql.settings.get_reapply_roles(ctx.guild)
+            reapply = self.bot.sql.settings.get_auto_reapply(ctx.guild)
             embed = discord.Embed(colour=discord.Colour.dark_teal())
             enabled = "enabled" if reapply else "disabled"
             embed.description = (
@@ -516,7 +516,7 @@ class Settings:
         else:
             # Set role reapplication
             with self.bot.sql.transaction():
-                self.bot.sql.settings.set_reapply_roles(ctx.guild, value)
+                self.bot.sql.settings.set_auto_reapply(ctx.guild, value)
 
             embed = discord.Embed(colour=discord.Colour.dark_teal())
             embed.description = (

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -541,11 +541,11 @@ class SettingsModel:
 
         upd = (
             self.tb_reapply_roles.update()
-            .where(self.tb_guild_settings.c.guild_id == guild.id)
+            .where(self.tb_reapply_roles.c.guild_id == guild.id)
             .values(auto_reapply=auto_reapply)
         )
         self.sql.execute(upd)
-        self.guild_settings_cache[guild].auto_reapply = auto_reapply
+        self.reapply_roles_cache[guild].auto_reapply = auto_reapply
 
     def add_to_tracking_blacklist(self, guild, user_or_channel):
         logger.info(


### PR DESCRIPTION
Some of the code were using the old SQL functions and causing runtime issues. The bug only affected role reapplication settings, not the system itself.