### PR TITLE
Load database items after migrating guilds table

### DIFF
--- a/futaba/client.py
+++ b/futaba/client.py
@@ -153,6 +153,10 @@ class Bot(commands.AutoShardedBot):
         # Performing migrations
         self.sql.guilds.migrate(self)
 
+        # Initialize cog databases
+        for cog in self.get_cogs():
+            cog.setup()
+
         # Finished
         pyver = sys.version_info
         logger.info("Powered by Python %d.%d.%d", pyver.major, pyver.minor, pyver.micro)
@@ -183,6 +187,9 @@ class Bot(commands.AutoShardedBot):
         # Put on event loop only after the database has successfully committed
         for task in tasks:
             task.execute_later()
+
+    def get_cogs(self):
+        return filter(None, map(self.get_cog, self.cogs))
 
     async def on_guild_join(self, guild):
         """

--- a/futaba/cogs/_core.py
+++ b/futaba/cogs/_core.py
@@ -32,3 +32,7 @@ class NameOfCog:
     def __init__(self, bot):
         self.bot = bot
         self.journal = bot.get_broadcaster("/A PATH THAT MAKES SENSE FOR THIS COG")
+
+    def setup(self):
+        # Fetching information from the database for this cog
+        pass

--- a/futaba/cogs/_core.py
+++ b/futaba/cogs/_core.py
@@ -22,15 +22,16 @@ from discord.ext import commands
 
 from futaba import permissions
 from futaba.exceptions import CommandFailed
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
 
-class NameOfCog:
-    __slots__ = ("bot", "journal")
+class NameOfCog(AbstractCog):
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/A PATH THAT MAKES SENSE FOR THIS COG")
 
     def setup(self):

--- a/futaba/cogs/abc.py
+++ b/futaba/cogs/abc.py
@@ -1,0 +1,25 @@
+#
+# cogs/abc.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+""" Abstract base class for all cog classes. """
+
+from abc import abstractmethod
+
+class AbstractCog:
+    __slots__ = ("bot",)
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @abstractmethod
+    def setup(self):
+        pass

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -67,6 +67,7 @@ class Filtering:
         self.check_member_join = async_partial(check_member_join, self)
         self.check_member_update = async_partial(check_member_update, self)
 
+    def setup(self):
         logger.info("Fetching previously stored filters")
         sql = self.bot.sql.filter
         for guild in self.bot.guilds:

--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -39,15 +39,15 @@ from .manage import (
     delete_content_filter,
     show_content_filter,
 )
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["Filtering"]
 
 
-class Filtering:
+class Filtering(AbstractCog):
     __slots__ = (
-        "bot",
         "journal",
         "filters",
         "content_filters",
@@ -58,7 +58,7 @@ class Filtering:
     )
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/filter")
         self.filters = defaultdict(dict)
         self.content_filters = defaultdict(dict)

--- a/futaba/cogs/info/alias.py
+++ b/futaba/cogs/info/alias.py
@@ -27,6 +27,7 @@ from futaba.download import download_link
 from futaba.exceptions import CommandFailed, SendHelp
 from futaba.str_builder import StringBuilder
 from futaba.utils import fancy_timedelta, user_discrim
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
@@ -50,15 +51,15 @@ class MemberChanges:
         return False
 
 
-class Alias:
+class Alias(AbstractCog):
     """
     Cog for member alias information.
     """
 
-    __slots__ = ("bot", "journal")
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/alias")
 
     def setup(self):

--- a/futaba/cogs/info/alias.py
+++ b/futaba/cogs/info/alias.py
@@ -61,6 +61,9 @@ class Alias:
         self.bot = bot
         self.journal = bot.get_broadcaster("/alias")
 
+    def setup(self):
+        pass
+
     async def member_update(self, before, after):
         """ Handles update of member information. """
 

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -37,6 +37,7 @@ from futaba.utils import (
     user_discrim,
 )
 from futaba.unicode import UNICODE_CATEGORY_NAME
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +51,8 @@ def get_unicode_url(emoji):
     )
 
 
-class Info:
-    """
-    Cog for informational commands.
-    """
-
-    def __init__(self, bot):
-        self.bot = bot
+class Info(AbstractCog):
+    """ Cog for informational commands. """
 
     def setup(self):
         pass

--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -58,6 +58,9 @@ class Info:
     def __init__(self, bot):
         self.bot = bot
 
+    def setup(self):
+        pass
+
     @commands.command(name="emoji", aliases=["emojis"])
     async def emoji(self, ctx, *, name: str):
         """

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -26,18 +26,19 @@ from futaba.converters import TextChannelConv
 from futaba.exceptions import CommandFailed, SendHelp
 from futaba.journal import ChannelOutputListener, Router
 from futaba.str_builder import StringBuilder
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["Journal"]
 
 
-class Journal:
-    __slots__ = ("bot", "router", "journal")
+class Journal(AbstractCog):
+    __slots__ = ("router", "journal")
 
     def __init__(self, bot):
+        super().__init__(bot)
         bot.journal_cog = self
-        self.bot = bot
         self.router = Router()
         self.journal = bot.get_broadcaster("/journal")
 

--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -41,10 +41,11 @@ class Journal:
         self.router = Router()
         self.journal = bot.get_broadcaster("/journal")
 
+    def setup(self):
         logger.info("Loading journal output channels from the database")
-        with bot.sql.transaction():
-            for guild in bot.guilds:
-                for output in bot.sql.journal.get_journal_channels(guild):
+        with self.bot.sql.transaction():
+            for guild in self.bot.guilds:
+                for output in self.bot.sql.journal.get_journal_channels(guild):
                     logger.info(
                         "Registering journal channel #%s (%d) for path '%s'",
                         output.channel.name,
@@ -54,7 +55,7 @@ class Journal:
                     self.router.register(
                         ChannelOutputListener(self.router, output.path, output.channel)
                     )
-        self.router.start(bot.loop)
+        self.router.start(self.bot.loop)
 
     @commands.group(name="journal", aliases=["log"])
     async def log(self, ctx):

--- a/futaba/cogs/misc/core.py
+++ b/futaba/cogs/misc/core.py
@@ -28,6 +28,7 @@ from futaba.download import download_links
 from futaba.exceptions import CommandFailed
 from futaba.str_builder import StringBuilder
 from futaba.utils import GIT_HASH, URL_REGEX, fancy_timedelta
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +37,11 @@ __all__ = ["Miscellaneous"]
 SHA1_ERROR_MESSAGE = "Error downloading file".ljust(40)
 
 
-class Miscellaneous:
-    __slots__ = ("bot", "journal")
+class Miscellaneous(AbstractCog):
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/misc")
 
     def setup(self):

--- a/futaba/cogs/misc/core.py
+++ b/futaba/cogs/misc/core.py
@@ -43,6 +43,9 @@ class Miscellaneous:
         self.bot = bot
         self.journal = bot.get_broadcaster("/misc")
 
+    def setup(self):
+        pass
+
     @commands.command(name="ping")
     async def ping(self, ctx):
         """ Determines the bot's current latency. """

--- a/futaba/cogs/misc/debug.py
+++ b/futaba/cogs/misc/debug.py
@@ -34,6 +34,9 @@ class Debugging:
         self.bot = bot
         self.journal = bot.get_broadcaster("/debug")
 
+    def setup(self):
+        pass
+
     @commands.command(name="testerror", hidden=True)
     @permissions.check_owner()
     async def test_error(self, ctx):

--- a/futaba/cogs/misc/debug.py
+++ b/futaba/cogs/misc/debug.py
@@ -10,9 +10,7 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-"""
-Cog for miscellaneous owner-only debugging commands.
-"""
+""" Cog for miscellaneous owner-only debugging commands. """
 
 import logging
 
@@ -21,17 +19,18 @@ from discord.ext import commands
 
 from futaba import permissions
 from futaba.enums import Reactions
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["Debugging"]
 
 
-class Debugging:
-    __slots__ = ("bot", "journal")
+class Debugging(AbstractCog):
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/debug")
 
     def setup(self):

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -25,6 +25,7 @@ from futaba.exceptions import CommandFailed
 from futaba.str_builder import StringBuilder
 from futaba.unicode import normalize_caseless
 from futaba.utils import escape_backticks, message_to_dict, user_discrim
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
@@ -50,11 +51,11 @@ class _Counter:
         self.value += 1
 
 
-class Cleanup:
-    __slots__ = ("bot", "journal", "dump")
+class Cleanup(AbstractCog):
+    __slots__ = ("journal", "dump")
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/moderation/cleanup")
         self.dump = bot.get_broadcaster("/dump/moderation/cleanup")
 

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -58,6 +58,9 @@ class Cleanup:
         self.journal = bot.get_broadcaster("/moderation/cleanup")
         self.dump = bot.get_broadcaster("/dump/moderation/cleanup")
 
+    def setup(self):
+        pass
+
     async def check_count(self, ctx, count):
         embed = discord.Embed(colour=discord.Colour.red())
         max_count = self.bot.sql.settings.get_max_delete_messages(ctx.guild)

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -34,15 +34,14 @@ __all__ = ["Moderation"]
 
 
 class Moderation:
-    """
-    Staff moderation commands
-    """
-
     __slots__ = ("bot", "journal")
 
     def __init__(self, bot):
         self.bot = bot
         self.journal = bot.get_broadcaster("/moderation")
+
+    def setup(self):
+        pass
 
     @staticmethod
     def build_reason(ctx, action, minutes, reason, past=False):

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -11,7 +11,7 @@
 #
 
 """
-Collection of moderation commands such as Ban/Kick
+Collection of moderation commands such as banning and muting.
 """
 
 import asyncio
@@ -27,17 +27,18 @@ from futaba.exceptions import CommandFailed, ManualCheckFailure
 from futaba.navi import ChangeRolesTask
 from futaba.str_builder import StringBuilder
 from futaba.utils import escape_backticks, plural, user_discrim
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["Moderation"]
 
 
-class Moderation:
-    __slots__ = ("bot", "journal")
+class Moderation(AbstractCog):
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/moderation")
 
     def setup(self):

--- a/futaba/cogs/moderation/manual_mod_action_warn.py
+++ b/futaba/cogs/moderation/manual_mod_action_warn.py
@@ -21,6 +21,7 @@ from discord import AuditLogAction
 
 from futaba.cogs.tracker import get_removal_cause
 from futaba.enums import ManualModActionType, MemberLeaveType
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
@@ -35,15 +36,10 @@ manual_mod_action_command_map = {
 }
 
 
-class ManualModActionWarn:
+class ManualModActionWarn(AbstractCog):
     """
     Warn moderators when they invoke a mod action manually.
     """
-
-    __slots__ = ("bot",)
-
-    def __init__(self, bot):
-        self.bot = bot
 
     def setup(self):
         pass

--- a/futaba/cogs/moderation/manual_mod_action_warn.py
+++ b/futaba/cogs/moderation/manual_mod_action_warn.py
@@ -15,7 +15,6 @@ Cog to warn when a mod action is done manually, instead of through the bot.
 """
 import logging
 from datetime import datetime, timedelta
-from enum import Enum
 
 from discord import AuditLogAction
 

--- a/futaba/cogs/moderation/manual_mod_action_warn.py
+++ b/futaba/cogs/moderation/manual_mod_action_warn.py
@@ -45,6 +45,9 @@ class ManualModActionWarn:
     def __init__(self, bot):
         self.bot = bot
 
+    def setup(self):
+        pass
+
     async def dispatch_manual_action_warning(
         self, guild, action, moderator, target_member, **kwargs
     ):

--- a/futaba/cogs/navi/core.py
+++ b/futaba/cogs/navi/core.py
@@ -26,15 +26,16 @@ from futaba.exceptions import CommandFailed
 from futaba.navi import SendMessageTask, build_navi_task
 from futaba.str_builder import StringBuilder
 from futaba.utils import escape_backticks, fancy_timedelta
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
 
-class Navi:
-    __slots__ = ("bot", "journal")
+class Navi(AbstractCog):
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/navi")
 
     def setup(self):

--- a/futaba/cogs/navi/core.py
+++ b/futaba/cogs/navi/core.py
@@ -37,10 +37,11 @@ class Navi:
         self.bot = bot
         self.journal = bot.get_broadcaster("/navi")
 
-        raw_tasks = bot.sql.navi.get_tasks()
+    def setup(self):
+        raw_tasks = self.bot.sql.navi.get_tasks()
         for raw_task in raw_tasks.values():
             try:
-                task = build_navi_task(bot, raw_task)
+                task = build_navi_task(self.bot, raw_task)
                 task.execute_later()
             except ValueError as error:
                 logger.warning(

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -23,6 +23,7 @@ from discord.ext import commands
 from futaba import permissions
 from futaba.exceptions import CommandFailed
 from futaba.str_builder import StringBuilder
+from ..abc import AbstractCog
 
 COGS_DIR = "futaba.cogs."
 
@@ -31,13 +32,13 @@ logger = logging.getLogger(__name__)
 __all__ = ["Reloader"]
 
 
-class Reloader:
-    __slots__ = ("bot", "journal")
+class Reloader(AbstractCog):
+    __slots__ = ("journal",)
 
     MANDATORY_COGS = ("journal", "navi", "reloader")
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/cog")
 
     def setup(self):

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -40,6 +40,9 @@ class Reloader:
         self.bot = bot
         self.journal = bot.get_broadcaster("/cog")
 
+    def setup(self):
+        pass
+
     def load_cog(self, cogname):
         if not cogname.startswith(COGS_DIR):
             cogname = f"{COGS_DIR}{cogname}"

--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -42,6 +42,9 @@ class SelfAssignableRoles:
             bot.sql.roles.get_assignable_roles(guild)
             bot.sql.roles.get_role_command_channels(guild)
 
+    def setup(self):
+        pass
+
     async def check_channel(self, ctx):
         ok_channels = self.bot.sql.roles.get_role_command_channels(ctx.guild)
 

--- a/futaba/cogs/roles/core.py
+++ b/futaba/cogs/roles/core.py
@@ -26,15 +26,16 @@ from futaba.converters import RoleConv, TextChannelConv
 from futaba.exceptions import CommandFailed, ManualCheckFailure, SendHelp
 from futaba.str_builder import StringBuilder
 from futaba.utils import escape_backticks
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
 
-class SelfAssignableRoles:
-    __slots__ = ("bot", "journal")
+class SelfAssignableRoles(AbstractCog):
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/roles")
 
         # Load self-assignable roles from database

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -42,9 +42,10 @@ class Settings:
         self.bot = bot
         self.journal = bot.get_broadcaster("/settings")
 
-        for guild in bot.guilds:
-            bot.sql.settings.get_special_roles(guild)
-            bot.sql.settings.get_reapply_roles(guild)
+    def setup(self):
+        for guild in self.bot.guilds:
+            self.bot.sql.settings.get_special_roles(guild)
+            self.bot.sql.settings.get_reapply_roles(guild)
 
     @commands.command(name="prefix")
     async def prefix(self, ctx, *, prefix: str = None):

--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -29,17 +29,18 @@ from futaba.emojis import ICONS
 from futaba.exceptions import CommandFailed, ManualCheckFailure, SendHelp
 from futaba.permissions import admin_perm, mod_perm
 from futaba.str_builder import StringBuilder
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["Settings"]
 
 
-class Settings:
-    __slots__ = ("bot", "journal")
+class Settings(AbstractCog):
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/settings")
 
     def setup(self):

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -127,6 +127,9 @@ class Tracker:
         self.reactions = deque(maxlen=20)
         self.typing = deque(maxlen=5)
 
+    def setup(self):
+        pass
+
     def __unload(self):
         """
         Remove listeners when unloading the cog.

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -24,6 +24,7 @@ from discord import AuditLogAction
 
 from futaba.enums import MemberLeaveType
 from futaba.utils import user_discrim
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
@@ -103,9 +104,8 @@ async def get_removal_cause(member, timestamp):
     )
 
 
-class Tracker:
+class Tracker(AbstractCog):
     __slots__ = (
-        "bot",
         "journal",
         "new_messages",
         "edited_messages",
@@ -117,7 +117,7 @@ class Tracker:
     )
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/tracking")
         self.new_messages = deque(maxlen=20)
         self.edited_messages = deque(maxlen=20)

--- a/futaba/cogs/welcome/alert.py
+++ b/futaba/cogs/welcome/alert.py
@@ -76,6 +76,9 @@ class Alert(AbstractCog):
                 alert = JoinAlert(guild, id, key, op, value)
                 self.alerts[id] = alert
 
+    def setup(self):
+        pass
+
     async def member_join(self, member):
         logger.info("Member '%s' (%d) joined, checking alerts.", member.name, member.id)
         for alert in self.alerts.values():

--- a/futaba/cogs/welcome/alert.py
+++ b/futaba/cogs/welcome/alert.py
@@ -26,6 +26,7 @@ from futaba.enums import JoinAlertKey, ValueRelationship
 from futaba.exceptions import CommandFailed, ManualCheckFailure, SendHelp
 from futaba.str_builder import StringBuilder
 from futaba.unicode import normalize_caseless
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
@@ -61,11 +62,11 @@ class JoinAlert:
         return f"{self.key.display_name} {self.op.symbol} {self.value}"
 
 
-class Alert:
-    __slots__ = ("bot", "journal", "alerts")
+class Alert(AbstractCog):
+    __slots__ = ("journal", "alerts")
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/welcome/alert")
         self.alerts = {}
 

--- a/futaba/cogs/welcome/alert.py
+++ b/futaba/cogs/welcome/alert.py
@@ -42,6 +42,9 @@ class JoinAlert:
         self.op = op
         self.value = value
 
+    def setup(self):
+        pass
+
     def matches(self, member):
         value = self.value
         member_value = getattr(member, self.attr)

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -27,6 +27,7 @@ from futaba.exceptions import CommandFailed, InvalidCommandContext, SendHelp
 from futaba.journal import ModerationListener
 from futaba.utils import user_discrim
 from .role_reapplication import RoleReapplication
+from ..abc import AbstractCog
 
 FakeContext = namedtuple("FakeContext", ("author", "channel", "guild"))
 logger = logging.getLogger(__name__)
@@ -79,11 +80,11 @@ def format_message(welcome_message, ctx):
     )
 
 
-class Welcome:
-    __slots__ = ("bot", "journal", "roles", "recently_joined")
+class Welcome(AbstractCog):
+    __slots__ = ("journal", "roles", "recently_joined")
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/welcome")
         self.roles = RoleReapplication(bot)
         self.recently_joined = deque(maxlen=5)

--- a/futaba/cogs/welcome/core.py
+++ b/futaba/cogs/welcome/core.py
@@ -91,8 +91,9 @@ class Welcome:
         self.add_listener()
         bot.add_cog(self.roles)
 
-        for guild in bot.guilds:
-            bot.sql.welcome.get_welcome(guild)
+    def setup(self):
+        for guild in self.bot.guilds:
+            self.bot.sql.welcome.get_welcome(guild)
 
     def add_listener(self):
         # Check if a moderation listener is already in place

--- a/futaba/cogs/welcome/role_reapplication.py
+++ b/futaba/cogs/welcome/role_reapplication.py
@@ -23,6 +23,7 @@ from discord.ext import commands
 from futaba.converters import UserConv
 from futaba.str_builder import StringBuilder
 from futaba.utils import user_discrim
+from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 FakeMember = namedtuple("FakeMember", ("name", "id", "guild"))
@@ -30,11 +31,11 @@ FakeMember = namedtuple("FakeMember", ("name", "id", "guild"))
 __all__ = ["RoleReapplication"]
 
 
-class RoleReapplication:
-    __slots__ = ("bot", "journal")
+class RoleReapplication(AbstractCog):
+    __slots__ = ("journal",)
 
     def __init__(self, bot):
-        self.bot = bot
+        super().__init__(bot)
         self.journal = bot.get_broadcaster("/roles")
 
     def setup(self):

--- a/futaba/cogs/welcome/role_reapplication.py
+++ b/futaba/cogs/welcome/role_reapplication.py
@@ -37,9 +37,10 @@ class RoleReapplication:
         self.bot = bot
         self.journal = bot.get_broadcaster("/roles")
 
-        with bot.sql.transaction():
-            for member in bot.get_all_members():
-                bot.sql.roles.update_saved_roles(member)
+    def setup(self):
+        with self.bot.sql.transaction():
+            for member in self.bot.get_all_members():
+                self.bot.sql.roles.update_saved_roles(member)
 
     async def member_update(self, before, after):
         if before.roles == after.roles:

--- a/futaba/cogs/welcome/role_reapplication.py
+++ b/futaba/cogs/welcome/role_reapplication.py
@@ -21,7 +21,6 @@ import discord
 from discord.ext import commands
 
 from futaba.converters import UserConv
-from futaba.str_builder import StringBuilder
 from futaba.utils import user_discrim
 from ..abc import AbstractCog
 


### PR DESCRIPTION
Ensures all cogs load stuff from the database after all migrations have occurred by making them inherit from `AbstractCog` and override the `setup()` method.

This was preventing a new instance of futaba from starting up due to database inconsistencies.