### PR TITLE
Replace "storage" classes with "data" classes

### DIFF
--- a/futaba/__main__.py
+++ b/futaba/__main__.py
@@ -23,8 +23,6 @@ from toml import TomlDecodeError
 from . import client
 from .config import InvalidConfigError, load_config
 
-# TODO replace sql "storage" classes with a different name and form
-
 LOG_FILE = "futaba.log"
 LOG_FILE_MODE = "w"
 LOG_FORMAT = "[%(levelname)s] %(asctime)s %(name)s: %(message)s"

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -11,7 +11,7 @@
 #
 
 """
-Holds the custom discord client
+Contains the bot's discord client and the necessary handling functionality.
 """
 
 import asyncio
@@ -256,6 +256,9 @@ class Bot(commands.AutoShardedBot):
         Handles errors when a command raises an exception.
         Some exceptions are "normal", such as CommandFailed or MissingRequiredArgument.
         """
+
+        # Complains about "context" vs "ctx"
+        # pylint: disable=arguments-differ
 
         async with self.message_lock(ctx.message):
             await ctx.message.clear_reactions()

--- a/futaba/sql/data/__init__.py
+++ b/futaba/sql/data/__init__.py
@@ -1,5 +1,5 @@
 #
-# sql/__init__.py
+# sql/data/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
 # Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
@@ -10,12 +10,12 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
-"""
-General module for all interfacing with the database.
-"""
-
-from . import data, hooks
-from .handle import SqlHandler
-from .transaction import Transaction
-
-__all__ = ["hooks", "SqlHandler", "Transaction"]
+from .filter import FilterSettingsData
+from .navi import NaviTaskData
+from .settings import (
+    GuildSettingsData,
+    ReapplyRolesData,
+    SpecialRoleData,
+    TrackingBlacklistData,
+)
+from .welcome import WelcomeData

--- a/futaba/sql/data/filter.py
+++ b/futaba/sql/data/filter.py
@@ -1,0 +1,31 @@
+#
+# sql/data/filter.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+
+class FilterSettingsData:
+    __slots__ = ("bot_immune", "manage_messages_immune", "reupload")
+
+    def __init__(self):
+        self.bot_immune = False
+        self.manage_messages_immune = True
+        self.reupload = True
+
+    def updated(self, field, value=None):
+        """
+        Sets 'field' if 'value' is not None. Returns the current value of 'field'.
+        Useful for getting an excluded field, and updating the storage object too.
+        """
+
+        if value is None:
+            setattr(self, field, value)
+
+        return getattr(self, field)

--- a/futaba/sql/data/navi.py
+++ b/futaba/sql/data/navi.py
@@ -1,0 +1,34 @@
+#
+# sql/data/navi.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+
+class NaviTaskData:
+    __slots__ = (
+        "id",
+        "guild_id",
+        "user_id",
+        "timestamp",
+        "recurrence",
+        "task_type",
+        "parameters",
+    )
+
+    def __init__(
+        self, id, guild_id, user_id, timestamp, recurrence, task_type, parameters
+    ):
+        self.id = id
+        self.guild_id = guild_id
+        self.user_id = user_id
+        self.timestamp = timestamp
+        self.recurrence = recurrence
+        self.task_type = task_type
+        self.parameters = parameters

--- a/futaba/sql/data/settings.py
+++ b/futaba/sql/data/settings.py
@@ -1,0 +1,125 @@
+#
+# sql/data/settings.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+import logging
+
+import discord
+
+from futaba.enums import LocationType
+from futaba.utils import partition_on
+
+logger = logging.getLogger(__name__)
+
+
+class GuildSettingsData:
+    __slots__ = ("prefix", "max_delete_messages", "warn_manual_mod_action")
+
+    def __init__(self, prefix, max_delete_messages, *, warn_manual_mod_action):
+        self.prefix = prefix
+        self.max_delete_messages = max_delete_messages
+        self.warn_manual_mod_action = warn_manual_mod_action
+
+
+class ReapplyRolesData:
+    __slots__ = ("roles", "auto_reapply")
+
+    def __init__(self, roles, auto_reapply):
+        self.roles = roles
+        self.auto_reapply = auto_reapply
+
+
+class SpecialRoleData:
+    __slots__ = ("guild", "member_role", "guest_role", "mute_role", "jail_role")
+
+    def __init__(
+        self, guild, member_role_id, guest_role_id, mute_role_id, jail_role_id
+    ):
+        self.guild = guild
+        self.member_role = self._get_role(member_role_id)
+        self.guest_role = self._get_role(guest_role_id)
+        self.mute_role = self._get_role(mute_role_id)
+        self.jail_role = self._get_role(jail_role_id)
+
+    def update(self, attrs):
+        logger.debug("Updating special role storage: %s", attrs)
+        if "member" in attrs:
+            self.member_role = attrs["member"]
+        if "guest" in attrs:
+            self.guest_role = attrs["guest"]
+        if "mute" in attrs:
+            self.mute_role = attrs["mute"]
+        if "jail" in attrs:
+            self.jail_role = attrs["jail"]
+
+    @property
+    def member(self):
+        return self.member_role
+
+    @property
+    def guest(self):
+        return self.guest_role
+
+    @property
+    def mute(self):
+        return self.mute_role
+
+    @property
+    def jail(self):
+        return self.jail_role
+
+    def _get_role(self, id):
+        if id is None:
+            return None
+
+        return discord.utils.get(self.guild.roles, id=id)
+
+    def __iter__(self):
+        yield self.member_role
+        yield self.guest_role
+        yield self.mute_role
+        yield self.jail_role
+
+
+class TrackingBlacklistData:
+    __slots__ = ("guild", "blacklisted_channels", "blacklisted_users")
+
+    def __init__(self, guild, blacklist):
+        # blacklist is an iterable of (type, data_id)
+
+        self.guild = guild
+        blacklisted_channels, blacklisted_users = partition_on(
+            lambda block: block[0] is LocationType.CHANNEL,
+            blacklist,
+            lambda block: block[1],
+        )
+
+        self.blacklisted_channels, self.blacklisted_users = (
+            set(blacklisted_channels),
+            set(blacklisted_users),
+        )
+
+    def is_blocked(self, user_or_channel):
+        if isinstance(user_or_channel, discord.abc.User):
+            return user_or_channel.id in self.blacklisted_users
+        return user_or_channel.id in self.blacklisted_channels
+
+    def add_block(self, user_or_channel):
+        if isinstance(user_or_channel, discord.abc.User):
+            self.blacklisted_users.add(user_or_channel.id)
+        else:
+            self.blacklisted_channels.add(user_or_channel.id)
+
+    def remove_block(self, user_or_channel):
+        if isinstance(user_or_channel, discord.abc.User):
+            self.blacklisted_users.discard(user_or_channel.id)
+        else:
+            self.blacklisted_channels.discard(user_or_channel.id)

--- a/futaba/sql/data/welcome.py
+++ b/futaba/sql/data/welcome.py
@@ -1,0 +1,54 @@
+#
+# sql/data/welcome.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2018 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+import discord
+
+
+class WelcomeData:
+    __slots__ = (
+        "guild",
+        "welcome_message",
+        "goodbye_message",
+        "agreed_message",
+        "delete_on_agree",
+        "welcome_channel",
+    )
+
+    def __init__(
+        self,
+        guild,
+        welcome_message=None,
+        goodbye_message=None,
+        agreed_message=None,
+        delete_on_agree=True,
+        welcome_channel_id=None,
+    ):
+        self.guild = guild
+        self.welcome_message = welcome_message
+        self.goodbye_message = goodbye_message
+        self.agreed_message = agreed_message
+        self.delete_on_agree = delete_on_agree
+        self.welcome_channel = discord.utils.get(
+            guild.text_channels, id=welcome_channel_id
+        )
+
+    @property
+    def channel(self):
+        return self.welcome_channel
+
+    @property
+    def channel_id(self):
+        return self.welcome_channel_id
+
+    @property
+    def welcome_channel_id(self):
+        return getattr(self.welcome_channel, "id", None)

--- a/futaba/sql/models/filter.py
+++ b/futaba/sql/models/filter.py
@@ -30,30 +30,11 @@ from sqlalchemy.sql import select
 from futaba.enums import FilterType, LocationType
 from futaba.unicode import normalize_caseless
 
+from ..data import FilterSettingsData
 from ..hooks import register_hook
 
 Column = functools.partial(Column, nullable=False)
 logger = logging.getLogger(__name__)
-
-
-class FilterSettingsStorage:
-    __slots__ = ("bot_immune", "manage_messages_immune", "reupload")
-
-    def __init__(self):
-        self.bot_immune = False
-        self.manage_messages_immune = True
-        self.reupload = True
-
-    def updated(self, field, value=None):
-        """
-        Sets 'field' if 'value' is not None. Returns the current value of 'field'.
-        Useful for getting an excluded field, and updating the storage object too.
-        """
-
-        if value is None:
-            setattr(self, field, value)
-
-        return getattr(self, field)
 
 
 __all__ = ["FilterModel"]
@@ -356,7 +337,7 @@ class FilterModel:
         bot_immune, manage_messages_immune, reupload = result.fetchone()
 
         # Update cache
-        storage = FilterSettingsStorage()
+        storage = FilterSettingsData()
         storage.bot_immune = bot_immune
         storage.manage_messages_immune = manage_messages_immune
         storage.reupload = reupload
@@ -371,7 +352,7 @@ class FilterModel:
 
     def add_settings(self, guild):
         logger.info("Adding filter settings for guild '%s' (%d)", guild.name, guild.id)
-        storage = FilterSettingsStorage()
+        storage = FilterSettingsData()
         ins = self.tb_filter_settings.insert().values(
             guild_id=guild.id,
             bot_immune=storage.bot_immune,

--- a/futaba/sql/models/navi.py
+++ b/futaba/sql/models/navi.py
@@ -37,37 +37,15 @@ from sqlalchemy import ForeignKey, Sequence
 from sqlalchemy.sql import select
 
 from futaba.enums import TaskType
+from ..data import NaviTaskData
 from ..hooks import register_hook
 
 Column = functools.partial(Column, nullable=False)
 logger = logging.getLogger(__name__)
 
-__all__ = ["NaviModel", "NaviTaskStorage"]
+__all__ = ["NaviModel"]
 
 ReminderInfo = namedtuple("ReminderInfo", ("id", "timestamp", "message"))
-
-
-class NaviTaskStorage:
-    __slots__ = (
-        "id",
-        "guild_id",
-        "user_id",
-        "timestamp",
-        "recurrence",
-        "task_type",
-        "parameters",
-    )
-
-    def __init__(
-        self, id, guild_id, user_id, timestamp, recurrence, task_type, parameters
-    ):
-        self.id = id
-        self.guild_id = guild_id
-        self.user_id = user_id
-        self.timestamp = timestamp
-        self.recurrence = recurrence
-        self.task_type = task_type
-        self.parameters = parameters
 
 
 class NaviModel:
@@ -135,7 +113,7 @@ class NaviModel:
                 task_type,
                 parameters,
             )
-            tasks[task_id] = NaviTaskStorage(
+            tasks[task_id] = NaviTaskData(
                 task_id, guild_id, user_id, timestamp, recurrence, task_type, parameters
             )
         return tasks

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -20,7 +20,6 @@ Has the model for managing the welcome cog and its functionality.
 import functools
 import logging
 
-import discord
 from sqlalchemy import and_
 from sqlalchemy import (
     BigInteger,
@@ -37,53 +36,13 @@ from sqlalchemy.sql import select
 
 from futaba.enums import JoinAlertKey, ValueRelationship
 from futaba.utils import lowerbool
+from ..data import WelcomeData
 from ..hooks import register_hook
 
 Column = functools.partial(Column, nullable=False)
 logger = logging.getLogger(__name__)
 
-__all__ = ["WelcomeModel", "WelcomeStorage"]
-
-
-class WelcomeStorage:
-    __slots__ = (
-        "guild",
-        "welcome_message",
-        "goodbye_message",
-        "agreed_message",
-        "delete_on_agree",
-        "welcome_channel",
-    )
-
-    def __init__(
-        self,
-        guild,
-        welcome_message=None,
-        goodbye_message=None,
-        agreed_message=None,
-        delete_on_agree=True,
-        welcome_channel_id=None,
-    ):
-        self.guild = guild
-        self.welcome_message = welcome_message
-        self.goodbye_message = goodbye_message
-        self.agreed_message = agreed_message
-        self.delete_on_agree = delete_on_agree
-        self.welcome_channel = discord.utils.get(
-            guild.text_channels, id=welcome_channel_id
-        )
-
-    @property
-    def channel(self):
-        return self.welcome_channel
-
-    @property
-    def channel_id(self):
-        return self.welcome_channel_id
-
-    @property
-    def welcome_channel_id(self):
-        return getattr(self.welcome_channel, "id", None)
+__all__ = ["WelcomeModel"]
 
 
 class WelcomeModel:
@@ -127,7 +86,7 @@ class WelcomeModel:
         logger.info(
             "Adding welcome message row for guild '%s' (%d)", guild.name, guild.id
         )
-        storage = WelcomeStorage(guild)
+        storage = WelcomeData(guild)
         ins = self.tb_welcome.insert().values(
             guild_id=guild.id,
             welcome_message=storage.welcome_channel,
@@ -177,7 +136,7 @@ class WelcomeModel:
             welcome_channel_id,
         ) = result.fetchone()
 
-        welcome = WelcomeStorage(
+        welcome = WelcomeData(
             guild,
             welcome_message,
             goodbye_message,


### PR DESCRIPTION
The name "storage" never really made sense, so I'm finally renaming them. Also moves them to a new submodule at `futaba.sql.data`.