### PR TITLE
Moderation commands rely on their respective permissions

### DIFF
--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -89,7 +89,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="nick", aliases=["nickname", "renick"])
     @commands.guild_only()
-    @permissions.check_mod()
+    @permissions.check_perm("manage_nicknames")
     async def nick(self, ctx, member: MemberConv, nick: str = None):
         """ Changes or reset a member's nickname. """
 
@@ -107,7 +107,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="mute", aliases=["shitpost"])
     @commands.guild_only()
-    @permissions.check_mod()
+    @permissions.check_perm("manage_roles")
     async def mute(self, ctx, member: MemberConv, minutes: int, *, reason: str = None):
         """
         Mutes the user for the given number of minutes.
@@ -144,7 +144,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="unmute", aliases=["unshitpost"])
     @commands.guild_only()
-    @permissions.check_mod()
+    @permissions.check_perm("manage_roles")
     async def unmute(
         self, ctx, member: MemberConv, minutes: int = 0, *, reason: str = None
     ):
@@ -173,7 +173,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="jail", aliases=["dunce"])
     @commands.guild_only()
-    @permissions.check_mod()
+    @permissions.check_perm("manage_roles")
     async def jail(self, ctx, member: MemberConv, minutes: int, *, reason: str = None):
         """
         Jails the user.
@@ -200,7 +200,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="unjail", aliases=["undunce"])
     @commands.guild_only()
-    @permissions.check_mod()
+    @permissions.check_perm("manage_roles")
     async def unjail(
         self, ctx, member: MemberConv, minutes: int = 0, *, reason: str = None
     ):
@@ -225,7 +225,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="kick")
     @commands.guild_only()
-    @permissions.check_mod()
+    @permissions.check_perm("kick_members")
     async def kick(self, ctx, user: UserConv, *, reason: str):
         """
         Kicks the user from the guild with a reason
@@ -248,7 +248,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="ban")
     @commands.guild_only()
-    @permissions.check_admin()
+    @permissions.check_perm("ban_members")
     async def ban(self, ctx, user: UserConv, *, reason: str):
         """
         Bans the user from the guild with a reason
@@ -273,7 +273,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="softban", aliases=["soft", "sban"])
     @commands.guild_only()
-    @permissions.check_admin()
+    @permissions.check_perm("ban_members")
     async def softban(self, ctx, user: UserConv, *, reason: str):
         """
         Soft-bans the user from the guild with a reason.
@@ -314,7 +314,7 @@ class Moderation(AbstractCog):
 
     @commands.command(name="unban", aliases=["pardon"])
     @commands.guild_only()
-    @permissions.check_admin()
+    @permissions.check_perm("ban_members")
     async def unban(self, ctx, user: UserConv, *, reason: str):
         """
         Unbans the id from the guild with a reason.

--- a/futaba/permissions.py
+++ b/futaba/permissions.py
@@ -28,9 +28,11 @@ __all__ = [
     "owner_perm",
     "admin_perm",
     "mod_perm",
+    "has_perm",
     "check_owner",
     "check_admin",
     "check_mod",
+    "check_perm",
 ]
 
 ELEVATED_PERMISSION_NAMES = (
@@ -140,11 +142,22 @@ def admin_perm(ctx: commands.Context):
 
 
 def mod_perm(ctx: commands.Context):
+    """ Check if the given member is a moderator. """
 
     if isinstance(ctx.channel, discord.abc.PrivateChannel):
         return False
 
     return is_mod_perm(ctx.channel.permissions_for(ctx.author))
+
+
+def has_perm(ctx: commands.Context, name: str):
+    """ Check if the given member has the specified permission. """
+
+    if isinstance(ctx.channel, discord.abc.PrivateChannel):
+        return False
+
+    perms = ctx.channel.permissions_for(ctx.author)
+    return getattr(perms, name)
 
 
 def check_owner():
@@ -157,7 +170,6 @@ def check_admin():
     """ Check if user is admin or higher """
 
     def checkperm(ctx):
-        """ Check the different perms """
         return owner_perm(ctx) or admin_perm(ctx)
 
     return commands.check(checkperm)
@@ -167,7 +179,19 @@ def check_mod():
     """ Check if user is moderator or higher """
 
     def checkperm(ctx):
-        """ Check the different perms """
         return owner_perm(ctx) or admin_perm(ctx) or mod_perm(ctx)
+
+    return commands.check(checkperm)
+
+
+def check_perm(name):
+    """ Check if user has the given permission """
+
+    perms = discord.Permissions()
+    if not hasattr(perms, name):
+        raise AttributeError(f"No such permission name: {name}")
+
+    def checkperm(ctx):
+        return has_perm(ctx, name)
 
     return commands.check(checkperm)


### PR DESCRIPTION
Instead of the previous nonsense about "moderators" vs "admins", there is a new decorator which simply checks the respective permission. Want to ban? Ok as long as you have `ban_members`.