### PR TITLE
Member ingest startup

### DIFF
--- a/futaba/cogs/welcome/role_reapplication.py
+++ b/futaba/cogs/welcome/role_reapplication.py
@@ -99,6 +99,8 @@ class RoleReapplication(AbstractCog):
     async def saved_roles(self, ctx, user: UserConv = None):
         """ Returns all roles that would be reapplied when a given user rejoins. """
 
+        # TODO integrate current punishment role if any
+
         if user is None:
             member = ctx.author
             mention = ctx.author.mention


### PR DESCRIPTION
Fixes #247 

This will greatly improve startup time for the bot, since the live production bot has 5k+ members to update.