### PR TITLE
Change on_guild_leave to set a flag

### DIFF
--- a/futaba/client.py
+++ b/futaba/client.py
@@ -215,7 +215,7 @@ class Bot(commands.AutoShardedBot):
 
         logger.info("Guild join event for '%s' (%d)", guild.name, guild.id)
         with self.sql.transaction():
-            self.sql.guilds.add_guild(guild)
+            self.sql.guilds.activate_guild(guild)
 
     async def on_guild_remove(self, guild):
         """
@@ -225,7 +225,7 @@ class Bot(commands.AutoShardedBot):
 
         logger.info("Guild leave event for '%s' (%d)", guild.name, guild.id)
         with self.sql.transaction():
-            self.sql.guilds.remove_guild(guild)
+            self.sql.guilds.deactivate_guild(guild)
 
     def message_lock(self, message):
         return self.message_locks.get_or_put(message, asyncio.Lock)

--- a/futaba/sql/models/filter.py
+++ b/futaba/sql/models/filter.py
@@ -99,7 +99,6 @@ class FilterModel:
         self.settings_cache = {}
 
         register_hook("on_guild_join", self.add_settings)
-        register_hook("on_guild_leave", self.remove_settings)
 
     def get_filters(self, location):
         logger.debug(
@@ -399,15 +398,3 @@ class FilterModel:
             )
         )
         self.sql.execute(upd)
-
-    def remove_settings(self, guild):
-        logger.info(
-            "Removing filter settings for guild '%s' (%d)", guild.name, guild.id
-        )
-
-        delet = self.tb_filter_settings.delete().where(
-            self.tb_filter_settings.c.guild_id == guild.id
-        )
-        result = self.sql.execute(delet)
-        assert result.rowcount in (0, 1), "Only one matching settings row"
-        self.settings_cache.pop(guild, None)

--- a/futaba/sql/models/guilds.py
+++ b/futaba/sql/models/guilds.py
@@ -51,7 +51,7 @@ class GuildsModel:
     # as this is where those hooks are invoked. This method itself is
     # called by the client on an actual guild join or leave event.
 
-    def add_guild(self, guild):
+    def activate_guild(self, guild):
         logger.info("Adding guild '%s' (%d) to guilds list", guild.name, guild.id)
 
         if guild.id in self.get_guild_ids():
@@ -67,7 +67,7 @@ class GuildsModel:
 
         run_hooks("on_guild_join", guild)
 
-    def remove_guild(self, guild):
+    def deactivate_guild(self, guild):
         logger.info("Removing guild '%s' (%d) from guilds list", guild.name, guild.id)
         run_hooks("on_guild_leave", guild)
 
@@ -107,10 +107,10 @@ class GuildsModel:
         with self.sql.transaction():
             for guild_id in current_guild_ids - migrated_guild_ids:
                 guild = self._get_guild(bot, guild_id)
-                self.add_guild(guild)
+                self.activate_guild(guild)
 
         logger.debug("Running deletions...")
         with self.sql.transaction():
             for guild_id in migrated_guild_ids - current_guild_ids:
                 guild = self._get_guild(bot, guild_id)
-                self.remove_guild(guild)
+                self.deactivate_guild(guild)

--- a/futaba/sql/models/guilds.py
+++ b/futaba/sql/models/guilds.py
@@ -23,7 +23,7 @@ import functools
 import logging
 from collections import namedtuple
 
-from sqlalchemy import BigInteger, Column, Table
+from sqlalchemy import Boolean, BigInteger, Column, Table
 from sqlalchemy.sql import select
 
 from ..hooks import run_hooks
@@ -41,7 +41,10 @@ class GuildsModel:
     def __init__(self, sql, meta):
         self.sql = sql
         self.tb_guilds = Table(
-            "guilds", meta, Column("guild_id", BigInteger, primary_key=True)
+            "guilds",
+            meta,
+            Column("guild_id", BigInteger, primary_key=True),
+            Column("active", Boolean, default=True),
         )
 
     # Note: Do NOT register the on_guild_join/on_guild_leave hooks here,
@@ -50,17 +53,35 @@ class GuildsModel:
 
     def add_guild(self, guild):
         logger.info("Adding guild '%s' (%d) to guilds list", guild.name, guild.id)
-        ins = self.tb_guilds.insert().values(guild_id=guild.id)
-        self.sql.execute(ins)
+
+        if guild.id in self.get_guild_ids():
+            upd = (
+                self.tb_guilds.update()
+                .values(active=True)
+                .where(self.tb_guilds.c.guild_id == guild.id)
+            )
+            self.sql.execute(upd)
+        else:
+            ins = self.tb_guilds.insert().values(guild_id=guild.id)
+            self.sql.execute(ins)
+
         run_hooks("on_guild_join", guild)
 
     def remove_guild(self, guild):
         logger.info("Removing guild '%s' (%d) from guilds list", guild.name, guild.id)
         run_hooks("on_guild_leave", guild)
+
+        upd = (
+            self.tb_guilds.update()
+            .values(active=False)
+            .where(self.tb_guilds.c.guild_id == guild.id)
+        )
+        self.sql.execute(upd)
+
         delet = self.tb_guilds.delete().where(self.tb_guilds.c.guild_id == guild.id)
         self.sql.execute(delet)
 
-    def get_guild_ids(self, bot):
+    def get_guild_ids(self):
         logger.info("Fetching guilds currently in database")
         sel = select([self.tb_guilds.c.guild_id])
         result = self.sql.execute(sel)
@@ -74,7 +95,7 @@ class GuildsModel:
         )
 
     def migrate(self, bot):
-        migrated_guild_ids = frozenset(self.get_guild_ids(self))
+        migrated_guild_ids = frozenset(self.get_guild_ids())
         current_guild_ids = frozenset(guild.id for guild in bot.guilds)
 
         logger.info(

--- a/futaba/sql/models/roles.py
+++ b/futaba/sql/models/roles.py
@@ -26,8 +26,6 @@ from sqlalchemy import ARRAY, BigInteger, Column, Table
 from sqlalchemy import ForeignKey, UniqueConstraint
 from sqlalchemy.sql import select
 
-from ..hooks import register_hook
-
 Column = functools.partial(Column, nullable=False)
 logger = logging.getLogger(__name__)
 
@@ -80,19 +78,6 @@ class RolesModel:
         self.roles_cache = {}
         self.channels_cache = {}
 
-        register_hook("on_guild_leave", self.remove_all_assignable_roles)
-        register_hook("on_guild_leave", self.remove_all_role_command_channels)
-
-    def remove_all_assignable_roles(self, guild):
-        logger.info(
-            "Remove all assignable roles for guild '%s' (%d)", guild.name, guild.id
-        )
-        delet = self.tb_assignable_roles.delete().where(
-            self.tb_assignable_roles.c.guild_id == guild.id
-        )
-        self.sql.execute(delet)
-        self.roles_cache.pop(guild, None)
-
     def get_assignable_roles(self, guild):
         logger.info(
             "Getting all assignable roles for guild '%s' (%d)", guild.name, guild.id
@@ -141,16 +126,6 @@ class RolesModel:
 
         if result.rowcount:
             self.roles_cache[guild].remove(role)
-
-    def remove_all_role_command_channels(self, guild):
-        logger.info(
-            "Remove all role command channels for guild '%s' (%d)", guild.name, guild.id
-        )
-        delet = self.tb_role_command_channels.delete().where(
-            self.tb_role_command_channels.c.guild_id == guild.id
-        )
-        self.sql.execute(delet)
-        self.channels_cache[guild].clear()
 
     def get_role_command_channels(self, guild):
         logger.info(

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -20,7 +20,6 @@ Has the model for managing the welcome cog and its functionality.
 import functools
 import logging
 
-from sqlalchemy import and_
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -79,8 +78,6 @@ class WelcomeModel:
         self.welcome_cache = {}
 
         register_hook("on_guild_join", self.add_welcome)
-        register_hook("on_guild_leave", self.remove_welcome)
-        register_hook("on_guild_leave", self.remove_all_alerts)
 
     def add_welcome(self, guild):
         logger.info(
@@ -245,19 +242,6 @@ class WelcomeModel:
         result = self.sql.execute(ins)
         alert.id, = result.inserted_primary_key
 
-    def remove_alert(self, guild, id):
-        logger.info("Remove join alert for guild '%s' (%d)", guild.name, guild.id)
-
-        delet = self.tb_join_alerts.delete().where(
-            and_(
-                self.tb_join_alerts.c.guild_id == guild.id,
-                self.tb_join_alerts.c.alert_id == id,
-            )
-        )
-        result = self.sql.execute(delet)
-        if result.rowcount != 1:
-            raise ValueError("No join alert with that id found")
-
     def get_all_alerts(self, guild):
         logger.info("Getting all join alerts for guild '%s' (%d)", guild.name, guild.id)
 
@@ -280,13 +264,3 @@ class WelcomeModel:
             value = key.parse_value(raw_value)
             alerts.append((id, key, op, value))
         return alerts
-
-    def remove_all_alerts(self, guild):
-        logger.info(
-            "Deleting all join alerts for guild '%s' (%d)", guild.name, guild.id
-        )
-
-        delet = self.tb_join_alerts.delete().where(
-            self.tb_join_alerts.c.guild_id == guild.id
-        )
-        self.sql.execute(delet)


### PR DESCRIPTION
In #174, it asks to remove the hook entirely. This PR instead sets a flag on the guild to not break foreign keys, and leaves the existing rows in the tables. 