### PR TITLE
Delay low-priority events when there's a backlog

### DIFF
--- a/futaba/cogs/journal/core.py
+++ b/futaba/cogs/journal/core.py
@@ -44,7 +44,7 @@ class Journal(AbstractCog):
     def __init__(self, bot):
         super().__init__(bot)
         bot.journal_cog = self
-        self.router = Router()
+        self.router = Router(bot)
         self.journal = bot.get_broadcaster("/journal")
 
     def setup(self):

--- a/futaba/delayed.py
+++ b/futaba/delayed.py
@@ -1,0 +1,47 @@
+#
+# delayed.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2019 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+"""
+An asynchronous queue that takes in lower-priority discord.py API events
+and sends them slowly over time. This prevents the bot from becoming
+slowed down or gridlocked over long-running or mass operations.
+"""
+
+import asyncio
+import inspect
+
+class DelayedQueue:
+    __slots__ = ("queue",)
+
+    def __init__(self):
+        self.queue = asyncio.Queue()
+
+    def start(self, eventloop):
+        loop.create_task(self.main_loop())
+
+    def push(self, coro):
+        assert inspect.iscoroutine(coro)
+        self.queue.put_nowait(coro)
+
+    async def main_loop(self):
+        while True:
+            logger.debug("Waiting for new delayed event")
+            coro = await self.queue.get()
+            await coro
+
+            logger.debug("Sleeping for %.1f seconds until next delayed event", self.delay)
+            await asyncio.sleep(self.delay)
+
+    @property
+    def delay(self):
+        mod_delay = self.queue.qsize() / 0.1
+        return min(mod_delay, 5)

--- a/futaba/delayed.py
+++ b/futaba/delayed.py
@@ -19,6 +19,7 @@ slowed down or gridlocked over long-running or mass operations.
 import asyncio
 import inspect
 
+
 class DelayedQueue:
     __slots__ = ("queue",)
 
@@ -38,7 +39,9 @@ class DelayedQueue:
             coro = await self.queue.get()
             await coro
 
-            logger.debug("Sleeping for %.1f seconds until next delayed event", self.delay)
+            logger.debug(
+                "Sleeping for %.1f seconds until next delayed event", self.delay
+            )
             await asyncio.sleep(self.delay)
 
     @property

--- a/futaba/delayed.py
+++ b/futaba/delayed.py
@@ -18,6 +18,9 @@ slowed down or gridlocked over long-running or mass operations.
 
 import asyncio
 import inspect
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class DelayedQueue:
@@ -27,7 +30,7 @@ class DelayedQueue:
         self.queue = asyncio.Queue()
 
     def start(self, eventloop):
-        loop.create_task(self.main_loop())
+        eventloop.create_task(self.main_loop())
 
     def push(self, coro):
         assert inspect.iscoroutine(coro)

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -59,4 +59,4 @@ class ChannelOutputListener(Listener):
             kwargs["files"] = list(map(copy_discord_file, attributes["files"]))
 
         coro = self.channel.send(**kwargs)
-        self.bot.queue.push(coro)
+        self.router.bot.queue.push(coro)

--- a/futaba/journal/impl/channel_output.py
+++ b/futaba/journal/impl/channel_output.py
@@ -58,4 +58,5 @@ class ChannelOutputListener(Listener):
         if "files" in attributes:
             kwargs["files"] = list(map(copy_discord_file, attributes["files"]))
 
-        await self.channel.send(**kwargs)
+        coro = self.channel.send(**kwargs)
+        self.bot.queue.push(coro)

--- a/futaba/journal/impl/direct_message.py
+++ b/futaba/journal/impl/direct_message.py
@@ -55,4 +55,5 @@ class DirectMessageListener(Listener):
         if "files" in attributes:
             kwargs["files"] = list(map(copy_discord_file, attributes["files"]))
 
-        await self.user.send(**kwargs)
+        coro = self.user.send(**kwargs)
+        self.bot.queue.push(coro)

--- a/futaba/journal/impl/direct_message.py
+++ b/futaba/journal/impl/direct_message.py
@@ -56,4 +56,4 @@ class DirectMessageListener(Listener):
             kwargs["files"] = list(map(copy_discord_file, attributes["files"]))
 
         coro = self.user.send(**kwargs)
-        self.bot.queue.push(coro)
+        self.router.bot.queue.push(coro)

--- a/futaba/journal/router.py
+++ b/futaba/journal/router.py
@@ -31,9 +31,10 @@ def attrs_match(obj, attrs):
 
 
 class Router:
-    __slots__ = ("paths", "queue", "history")
+    __slots__ = ("bot", "paths", "queue", "history")
 
-    def __init__(self):
+    def __init__(self, bot):
+        self.bot = bot
         self.paths = defaultdict(list)
         self.queue = asyncio.Queue()
         self.history = deque(maxlen=1024)


### PR DESCRIPTION
When we do stuff like `!prune`, the bot generates a lot of API calls as it kicks, outputs messages in each of the journal channels, etc. This has creates a delayed task scheduler which runs items, and has all journal messaging go through it.