### PR TITLE
Limit maximum roles in !uinfo

### DIFF
--- a/futaba/cogs/info/core.py
+++ b/futaba/cogs/info/core.py
@@ -45,6 +45,8 @@ from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)
 
+MAX_ROLES_SHOWN = 20
+
 __all__ = ["Info"]
 
 
@@ -269,9 +271,12 @@ class Info(AbstractCog):
 
         # Roles
         if getattr(user, "roles", None):
-            roles = " ".join(
-                role.mention for role in islice(user.roles, 1, len(user.roles))
-            )
+            roles_len = min(len(user.roles), MAX_ROLES_SHOWN + 1)
+            roles = " ".join(role.mention for role in islice(user.roles, 1, roles_len))
+
+            if len(user.roles) > roles_len:
+                roles = f"{roles} (and {len(user.roles) - roles_len} others)"
+
             if roles:
                 embed.add_field(name="Roles", value=roles)
 


### PR DESCRIPTION
Running `!uinfo` on a user with a lot of roles resulted in the message payload being too large, causing the send to fail.

This PR adds a constant limit of 20, after which the count is displayed instead:
(limit was lowered for the purposes of the screenshot)
![image](https://user-images.githubusercontent.com/8848022/57985792-51782c00-7a3b-11e9-9754-8862f8201a40.png)
