### PR TITLE
JSON serialize assets

### DIFF
--- a/futaba/dict_convert.py
+++ b/futaba/dict_convert.py
@@ -47,7 +47,7 @@ def user_dict(user):
         "id": user.id,
         "name": user.name,
         "discriminator": user.discriminator,
-        "avatar": user.avatar,
+        "avatar": str(user.avatar),
         "bot": user.bot,
     }
 
@@ -58,7 +58,7 @@ def member_dict(member):
         "name": member.name,
         "discriminator": member.discriminator,
         "nick": member.nick,
-        "avatar": member.avatar,
+        "avatar": str(member.avatar),
         "bot": member.bot,
         "joined_at": member.joined_at.isoformat(),
         "status": str(member.status),
@@ -100,7 +100,7 @@ def emoji_dict(emoji):
             "animated": emoji.animated,
             "managed": getattr(emoji, "managed", False),
             "guild_id": map_or(str, getattr(emoji, "guild_id", None)),
-            "url": emoji.url,
+            "url": str(emoji.url),
         }
 
 


### PR DESCRIPTION
Recently we got this error when doing cleanup:
```python
Traceback (most recent call last):

  File "/usr/local/lib/python3.7/dist-packages/discord/ext/commands/core.py", line 63, in wrapped
    ret = await coro(*args, **kwargs)

  File "/home/futaba/repo/futaba/cogs/moderation/cleanup.py", line 179, in cleanup_id
    obj, file = self.dump_messages(messages)

  File "/home/futaba/repo/futaba/cogs/moderation/cleanup.py", line 90, in dump_messages
    json.dump(obj, buffer, ensure_ascii=True, indent=4)

  File "/usr/lib/python3.7/json/__init__.py", line 179, in dump
    for chunk in iterable:

  File "/usr/lib/python3.7/json/encoder.py", line 429, in _iterencode
    yield from _iterencode_list(o, _current_indent_level)

  File "/usr/lib/python3.7/json/encoder.py", line 325, in _iterencode_list
    yield from chunks

  File "/usr/lib/python3.7/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks

  File "/usr/lib/python3.7/json/encoder.py", line 325, in _iterencode_list
    yield from chunks

  File "/usr/lib/python3.7/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks

  File "/usr/lib/python3.7/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks

  File "/usr/lib/python3.7/json/encoder.py", line 438, in _iterencode
    o = _default(o)

  File "/usr/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '

TypeError: Object of type Asset is not JSON serializable
```

This is the result of `discord.Asset` being added instead strings (URLs) for some types such as images. 