### PR TITLE
Fix prune

### DIFF
--- a/futaba/cogs/welcome/prune.py
+++ b/futaba/cogs/welcome/prune.py
@@ -39,10 +39,13 @@ def prune_filter(member, prune_date, *, has_roles, lacks_roles):
     if member.bot:
         return False
 
-    for role in member.roles:
-        if role not in has_roles:
+    # Ensures that all roles in has_roles exist in member.roles
+    for role in has_roles:
+        if role not in member.roles:
             return False
 
+    # Ensure that all roles aren't in lacks_roles
+    for role in member.roles:
         if role in lacks_roles:
             return False
 


### PR DESCRIPTION
The filter condition was incorrect and would exclude all members, leading to the following:

![bad-prune-condition](https://user-images.githubusercontent.com/8848022/58376757-e00b1280-7f3f-11e9-91f4-0592b44f82a9.png)


