### PR TITLE
Add configuration schema validator

### DIFF
--- a/futaba/__main__.py
+++ b/futaba/__main__.py
@@ -18,10 +18,11 @@ import logging
 import argparse
 import sys
 
+import schema
 from toml import TomlDecodeError
 
 from . import client
-from .config import InvalidConfigError, load_config
+from .config import load_config
 
 LOG_FILE = "futaba.log"
 LOG_FILE_MODE = "w"
@@ -91,7 +92,7 @@ if __name__ == "__main__":
     except (TomlDecodeError, IOError) as error:
         logger.error("Unable to read configuration file.", exc_info=error)
         exit(1)
-    except InvalidConfigError as error:
+    except schema.SchemaError as error:
         logger.error("Error when processing configuration file: %s", error)
         exit(1)
 

--- a/futaba/cogs/optional/__init__.py
+++ b/futaba/cogs/optional/__init__.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 def setup(bot):
-    for cog_name, enabled in bot.config.optional_cogs.items():
+    for cog_name, options in bot.config.optional_cogs.items():
+        enabled = options.enabled
         logger.info(
             "Optional cog: %s %s", " [ENABLED]" if enabled else "[DISABLED]", cog_name
         )

--- a/futaba/cogs/optional/example/core.py
+++ b/futaba/cogs/optional/example/core.py
@@ -14,6 +14,9 @@
 Example optional cog.
 """
 
+# REMOVE THIS IN REGULAR COGS:
+# pylint: disable=unused-import
+
 import asyncio
 import logging
 import math

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -31,6 +31,7 @@ def _check_gtz(type):
         except ValueError:
             return False
         return value > 0
+
     return wrapper
 
 

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -70,7 +70,8 @@ def load_config(path):
 
     optional_cogs = _get(config, "cogs")
     for key, value in optional_cogs.items():
-        if not isinstance(value, bool):
+        enabled = _get(value, "enabled", key)
+        if not isinstance(enabled, bool):
             raise InvalidConfigError(f"Cog setting for {key} is not a boolean", config)
 
     try:

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -30,9 +30,7 @@ def _check_gtz(type):
             value = type(value)
         except ValueError:
             return False
-
         return value > 0
-
     return wrapper
 
 

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -17,10 +17,47 @@ Loads configuration files from disk
 from collections import namedtuple
 
 import toml
+from schema import Schema, And, Or
 
-from futaba.exceptions import InvalidConfigError
+from futaba.converters import ID_REGEX
 
 __all__ = ["Configuration", "load_config"]
+
+# Helper function to check that the value is greater than zero
+def _check_gtz(type):
+    def wrapper(value):
+        try:
+            value = type(value)
+        except ValueError:
+            return False
+
+        return value > 0
+
+    return wrapper
+
+
+ConfigurationSchema = Schema(
+    {
+        "bot": {
+            "token": And(str, len),
+            "owners": [And(str, ID_REGEX.match)],
+            "prefix": str,
+            "error-channel-id": And(str, ID_REGEX.match),
+        },
+        "cogs": {"example": object, "statbot": object},
+        "moderation": {"max-cleanup-messages": And(str, _check_gtz(int))},
+        "delay": {
+            "chunk-size": And(str, _check_gtz(int)),
+            "sleep": And(str, _check_gtz(float)),
+        },
+        "emojis": {
+            "anger": Or(And(str, ID_REGEX.match), "0"),
+            "python": Or(And(str, ID_REGEX.match), "0"),
+            "discordpy": Or(And(str, ID_REGEX.match), "0"),
+        },
+        "database": {"url": And(str, len)},
+    }
+)
 
 Configuration = namedtuple(
     "Configuration",
@@ -41,88 +78,23 @@ Configuration = namedtuple(
 )
 
 
-def _get(config, field, path=None):
-    if field not in config:
-        if path is None:
-            raise InvalidConfigError(
-                f"No '{field}' section found in configuration.", config
-            )
-        else:
-            raise InvalidConfigError(
-                f"No '{path}.{field}' field found in configuration.", config
-            )
-
-    return config[field]
-
-
 def load_config(path):
     with open(path) as fh:
         config = toml.load(fh)
 
-    config_bot = _get(config, "bot")
-    token = _get(config_bot, "token", "bot")
-    prefix = _get(config_bot, "prefix", "bot")
-
-    try:
-        error_channel_id = int(_get(config_bot, "error-channel-id", "bot"))
-    except ValueError:
-        raise InvalidConfigError("Channel IDs must be integers", config)
-
-    optional_cogs = _get(config, "cogs")
-    for key, value in optional_cogs.items():
-        enabled = _get(value, "enabled", key)
-        if not isinstance(enabled, bool):
-            raise InvalidConfigError(f"Cog setting for {key} is not a boolean", config)
-
-    try:
-        owner_ids = [int(id) for id in _get(config_bot, "owners", "bot")]
-    except ValueError:
-        raise InvalidConfigError("Owner IDs must be integers", config)
-
-    config_moderation = _get(config, "moderation")
-
-    try:
-        max_cleanup_messages = int(
-            _get(config_moderation, "max-cleanup-messages", "moderation")
-        )
-        if max_cleanup_messages <= 0:
-            raise ValueError
-    except ValueError:
-        raise InvalidConfigError(
-            "Maximum cleanup messages value must be a positive integer", config
-        )
-
-    config_delay = _get(config, "delay")
-
-    try:
-        delay_chunk_size = int(_get(config_delay, "chunk-size", "delay"))
-        delay_sleep = float(_get(config_delay, "sleep", "delay"))
-    except ValueError:
-        raise InvalidConfigError("Delay values must be numbers", config)
-
-    config_emoji = _get(config, "emojis")
-
-    try:
-        anger_emoji_id = int(_get(config_emoji, "anger", "emojis"))
-        python_emoji_id = int(_get(config_emoji, "python", "emojis"))
-        discord_py_emoji_id = int(_get(config_emoji, "discordpy", "emojis"))
-    except ValueError:
-        raise InvalidConfigError("Emoji IDs must be integers", config)
-
-    config_db = _get(config, "database")
-    db_url = _get(config_db, "url", "database")
+    ConfigurationSchema.validate(config)
 
     return Configuration(
-        token=token,
-        owner_ids=owner_ids,
-        default_prefix=prefix,
-        error_channel_id=error_channel_id,
-        optional_cogs=optional_cogs,
-        max_cleanup_messages=max_cleanup_messages,
-        delay_chunk_size=delay_chunk_size,
-        delay_sleep=delay_sleep,
-        anger_emoji_id=anger_emoji_id,
-        python_emoji_id=python_emoji_id,
-        discord_py_emoji_id=discord_py_emoji_id,
-        database_url=db_url,
+        token=config["bot"]["token"],
+        owner_ids=[int(id) for id in config["bot"]["owners"]],
+        default_prefix=config["bot"]["prefix"],
+        error_channel_id=int(config["bot"]["error-channel-id"]),
+        optional_cogs=config["cogs"],
+        max_cleanup_messages=int(config["moderation"]["max-cleanup-messages"]),
+        delay_chunk_size=int(config["delay"]["chunk-size"]),
+        delay_sleep=float(config["delay"]["sleep"]),
+        anger_emoji_id=int(config["emojis"]["anger"]),
+        python_emoji_id=int(config["emojis"]["python"]),
+        discord_py_emoji_id=int(config["emojis"]["discordpy"]),
+        database_url=config["database"]["url"],
     )

--- a/futaba/exceptions.py
+++ b/futaba/exceptions.py
@@ -12,13 +12,7 @@
 
 from discord.ext.commands import CommandError
 
-__all__ = [
-    "CommandFailed",
-    "ManualCheckFailure",
-    "SendHelp",
-    "InvalidCommandContext",
-    "InvalidConfigError",
-]
+__all__ = ["CommandFailed", "ManualCheckFailure", "SendHelp", "InvalidCommandContext"]
 
 
 class SendOnError(CommandError):
@@ -48,9 +42,3 @@ class SendHelp(CommandError):
 
 class InvalidCommandContext(CommandError):
     pass
-
-
-class InvalidConfigError(RuntimeError):
-    def __init__(self, message, config):
-        super().__init__(message)
-        self.config = config

--- a/misc/config.toml
+++ b/misc/config.toml
@@ -13,10 +13,13 @@ prefix = "!"
 # Set to "0" to disable
 error-channel-id = "488543452305555456"
 
-[cogs]
 # Settings for optional cogs
-example = true
-statbot = false
+[cogs.example]
+enabled = true
+
+[cogs.statbot]
+url = "postgres://statbot:passwordhere@localhost/statbot_ro"
+enabled = false
 
 [moderation]
 # Maximum number of messages that may be specified

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ confusable_homoglyphs>=3.0
 dateparser>=0.7
 discord.py>=1.0.1
 psycopg2>=2.5
+schema>=0.6
 textdistance>=3.0
 toml>=0.9


### PR DESCRIPTION
Fixes #296 

Uses the python library [`schema`](https://github.com/keleshev/schema) to verify our configuration file meets a premade specification.