### PR TITLE
Allow multiple punishment roles on a single person

### DIFF
--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -81,6 +81,7 @@ class Moderation(AbstractCog):
         self.bot.add_tasks(task)
 
     def check_other_roles(self, member):
+        # FIXME
         has_other, punish_role, _ = self.bot.sql.moderation.get_other_roles(member)
         if has_other:
             embed = discord.Embed(colour=discord.Colour.red())

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -80,21 +80,6 @@ class Moderation(AbstractCog):
         )
         self.bot.add_tasks(task)
 
-    def check_other_roles(self, member):
-        # FIXME
-        has_other, punish_role, _ = self.bot.sql.moderation.get_other_roles(member)
-        if has_other:
-            embed = discord.Embed(colour=discord.Colour.red())
-            role_descr = (
-                ""
-                if punish_role is None
-                else f"because they already have {punish_role.mention}"
-            )
-            embed.description = (
-                f"Cannot add a new overriding role to {member.mention} {role_descr}"
-            )
-            raise CommandFailed(embed=embed)
-
     @commands.command(name="nick", aliases=["nickname", "renick"])
     @commands.guild_only()
     @permissions.check_perm("manage_nicknames")
@@ -139,8 +124,6 @@ class Moderation(AbstractCog):
 
         if member.top_role >= ctx.me.top_role:
             raise ManualCheckFailure("I don't have permission to mute this user")
-
-        self.check_other_roles(member)
 
         # TODO store punishment in table with task ID
 
@@ -210,8 +193,6 @@ class Moderation(AbstractCog):
 
         if member.top_role >= ctx.me.top_role:
             raise ManualCheckFailure("I don't have permission to jail this user")
-
-        self.check_other_roles(member)
 
         # TODO store punishment in table with task ID
 

--- a/futaba/punishment.py
+++ b/futaba/punishment.py
@@ -39,21 +39,9 @@ class PunishmentHandler:
 
         return role
 
-    def check_other_roles(self, member):
-        has_other, _, _ = self.bot.sql.moderation.get_other_roles(member)
-        if has_other:
-            logger.warning(
-                "Cannot add an overriding role to '%s' (%d)", member.name, member.id
-            )
-
-        return not has_other
-
     async def apply(self, name, guild, member, reason):
         role = self.get_role(name, guild)
         if role is None:
-            return
-
-        if not self.check_other_roles(member):
             return
 
         if member.top_role > guild.me.top_role:


### PR DESCRIPTION
Note that because of the restore_other_roles option, if you unjail a user who is both muted and jailed, both punishment roles are removed.