### PR TITLE
Allow multiple transactions

### DIFF
--- a/futaba/sql/handle.py
+++ b/futaba/sql/handle.py
@@ -79,6 +79,7 @@ class SqlHandler:
         return self.conn.execute(*args, **kwargs)
 
     def transaction(self, trans_logger=logger):
-        assert self.trans is None, "Already in a transaction"
-        self.trans = Transaction(self, self.conn, trans_logger)
+        if self.trans is None:
+            self.trans = Transaction(self, self.conn, trans_logger)
+
         return self.trans


### PR DESCRIPTION
```py
Traceback (most recent call last):

  File "/usr/local/lib/python3.7/dist-packages/discord/ext/commands/core.py", line 63, in wrapped
    ret = await coro(*args, **kwargs)

  File "/home/futaba/repo/futaba/cogs/moderation/core.py", line 138, in mute
    ctx, member, minutes, PunishAction.RELIEVE_MUTE, reason

  File "/home/futaba/repo/futaba/cogs/moderation/core.py", line 81, in remove_roles
    self.bot.add_tasks(task)

  File "/home/futaba/repo/futaba/client.py", line 207, in add_tasks
    with self.sql.transaction():

  File "/home/futaba/repo/futaba/sql/handle.py", line 82, in transaction
    assert self.trans is None, "Already in a transaction"

AssertionError: Already in a transaction
```