### PR TITLE
Initial addition of statbot cog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ Features that are global or generic enough to exist everywhere in the bot should
 
 If your cog is necessary for the proper function of the bot (this is very unlikely to be true), then you must make it a "mandatory" cog. These cannot be loaded/unloaded/reloaded once the bot has started, and are to some extent tied to the `Client` object itself. Currently the only two mandatory cogs are the reloader itself and the journal router.
 
+All other functionality, such as that which depends on specific third-party applications like [Statbot](https://github.com/strinking/statbot), should be an "optional" cog. This means they are placed in `futaba/cogs/optional/`, and must be explicitly enabled in the bot's config or loaded manually by the bot owner.
+
 When you need to store information persistently, a database model should be created in `futaba/sql/`. (NOTE: This will definitely change when [#13](https://github.com/strinking/futaba/issues/13) is merged). A model example can be copied from the template, but the general principle is that the `__init__` declares all the tables, and sets up in-memory caches for tables as needed. Then methods should be created that allow interacting with the table from in a SQL-agnostic, logical way. SQLAlchemy, and especially raw SQL should **never** be present outside of `futaba/sql/models/`.
 
 If you want to set up a delayed task, use Navi, Futaba's internal job scheduler. If your function cannot fit into one of the existing `Task` objects, create a new one and provide a way to serialize/deserialize it into JSON for persistent storage in the database. In rare cases where the delay is very short, an `asyncio.sleep()` may be acceptable. Never use `time.sleep()`, that chokes up the event loop.

--- a/futaba/cogs/optional/__init__.py
+++ b/futaba/cogs/optional/__init__.py
@@ -12,8 +12,6 @@
 
 import logging
 
-from . import example
-
 logger = logging.getLogger(__name__)
 
 

--- a/futaba/cogs/optional/example/core.py
+++ b/futaba/cogs/optional/example/core.py
@@ -50,11 +50,11 @@ class ExampleCog(AbstractCog):
         """
 
         embed = discord.Embed(colour=discord.Colour.teal())
-        embed.set_author(name="Input: {number}")
+        embed.set_author(name=f"Input: {number}")
         embed.description = (
-            f"Square root: {math.sqrt(number)}\n"
-            f"Natural logarithm: {math.log(number)}\n"
-            f"Sine / cosine: {math.sin(number)} / {math.cos(number)}"
+            f"Square root: `{math.sqrt(number)}`\n"
+            f"Natural logarithm: `{math.log(number)}`\n"
+            f"Sine / cosine: `{math.sin(number)}` / `{math.cos(number)}`"
         )
         await ctx.send(embed=embed)
 

--- a/futaba/cogs/optional/statbot/__init__.py
+++ b/futaba/cogs/optional/statbot/__init__.py
@@ -1,0 +1,18 @@
+#
+# cogs/optional/statbot/__init__.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2019 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+from .core import StatbotCog
+
+
+def setup(bot):
+    cog = StatbotCog(bot)
+    bot.add_cog(cog)

--- a/futaba/cogs/optional/statbot/core.py
+++ b/futaba/cogs/optional/statbot/core.py
@@ -69,13 +69,13 @@ class StatbotCog(AbstractCog):
             len(items),
         )
 
-        base_link = f"https://ddd.raylu.net/guild/{ctx.guild.id}/"
         params = {}
-
         for item in items:
             if isinstance(item, discord.TextChannel):
                 params["channel_id"] = item.id
             elif isinstance(item, discord.abc.User):
                 params["int_user_id"] = int_hash(item.id)
 
-        await ctx.send(content=f"{base_link}{'?' if params else ''}{urlencode(params)}")
+        await ctx.send(
+            content=f"https://ddd.raylu.net/guild/{ctx.guild.id}/{'?' if params else ''}{urlencode(params)}"
+        )

--- a/futaba/cogs/optional/statbot/core.py
+++ b/futaba/cogs/optional/statbot/core.py
@@ -1,0 +1,40 @@
+#
+# cogs/optional/statbot/core.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2019 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+"""
+Cog for querying a local statbot database.
+"""
+
+import asyncio
+import logging
+import math
+
+import discord
+from discord.ext import commands
+
+from futaba import permissions
+from futaba.cogs.abc import AbstractCog
+from futaba.exceptions import CommandFailed
+
+logger = logging.getLogger(__name__)
+
+
+class StatbotCog(AbstractCog):
+    __slots__ = ("journal",)
+
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.journal = bot.get_broadcaster("/statbot")
+
+    def setup(self):
+        # Fetching information from the database for this cog
+        pass

--- a/futaba/cogs/optional/statbot/core.py
+++ b/futaba/cogs/optional/statbot/core.py
@@ -15,17 +15,32 @@ Cog for querying a local statbot database.
 """
 
 import asyncio
+import hashlib
 import logging
-import math
+import struct
+from urllib.parse import urlencode
+from typing import Union
 
 import discord
 from discord.ext import commands
 
 from futaba import permissions
+from futaba.converters import TextChannelConv, UserConv
 from futaba.cogs.abc import AbstractCog
 from futaba.exceptions import CommandFailed
 
 logger = logging.getLogger(__name__)
+
+
+def int_hash(num):
+    """
+    The integer hashing algorithm used by Statbot to transform real user IDs.
+    """
+
+    data = struct.pack(">q", num)
+    hashed = hashlib.sha512(data).digest()
+    (result,) = struct.unpack(">q", hashed[24:32])
+    return result
 
 
 class StatbotCog(AbstractCog):
@@ -38,3 +53,29 @@ class StatbotCog(AbstractCog):
     def setup(self):
         # Fetching information from the database for this cog
         pass
+
+    @commands.command(name="ddd", aliases=["dddlink", "dddurl"])
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def ddd(self, ctx, *items: Union[TextChannelConv, UserConv]):
+        """
+        Gets the ddd (Discord Data Delver, by raylu) link for the item specified.
+        """
+
+        logger.info(
+            "Producing ddd link for guild '%s' (%d) [%d arguments]",
+            ctx.guild.name,
+            ctx.guild.id,
+            len(items),
+        )
+
+        base_link = f"https://ddd.raylu.net/guild/{ctx.guild.id}/"
+        params = {}
+
+        for item in items:
+            if isinstance(item, discord.TextChannel):
+                params["channel_id"] = item.id
+            elif isinstance(item, discord.abc.User):
+                params["int_user_id"] = int_hash(item.id)
+
+        await ctx.send(content=f"{base_link}{'?' if params else ''}{urlencode(params)}")


### PR DESCRIPTION
Fixes #243 
For #203 

Adds the new optional statbot cog, though currently only has the `!ddd` command.

![screenshot](https://user-images.githubusercontent.com/8848022/58432005-60379200-807e-11e9-9b4f-1781e1d4b612.png)
