### PR TITLE
Disable command group help messages

### DIFF
--- a/futaba/client.py
+++ b/futaba/client.py
@@ -84,7 +84,7 @@ class Bot(commands.AutoShardedBot):
             fetch_offline_members=True,
         )
 
-        self.help_command = commands.DefaultHelpCommand(width=90, dm_help=True)
+        self.help_command = commands.MinimalHelpCommand(width=90, dm_help=True)
 
     @staticmethod
     def my_command_prefix(bot, message):
@@ -347,7 +347,6 @@ class Bot(commands.AutoShardedBot):
         elif isinstance(error, SendHelp):
             logger.info("Manually sending help for command")
             # FIXME no help provider set up
-            await self.help_command.send_command_help(ctx.command)
             await Reactions.HELP.add(ctx.message)
 
         elif isinstance(error, commands.errors.CommandInvokeError):

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -346,8 +346,9 @@ class Bot(commands.AutoShardedBot):
 
         elif isinstance(error, SendHelp):
             logger.info("Manually sending help for command")
+            # FIXME no help provider set up
             await self.help_command.send_command_help(ctx.command)
-            await Reactions.SUCCESS.add(ctx.message)
+            await Reactions.HELP.add(ctx.message)
 
         elif isinstance(error, commands.errors.CommandInvokeError):
             logger.debug("Handling CommandInvokeError...")

--- a/futaba/enums.py
+++ b/futaba/enums.py
@@ -25,6 +25,7 @@ class Reactions(Enum):
     MISSING = "\N{BLACK QUESTION MARK ORNAMENT}"
     WAITING = "\N{HOURGLASS}"
     NETWORK = "\N{ELECTRIC PLUG}"
+    HELP = "\N{BOOKS}"
 
     async def add(self, message: discord.Message):
         try:


### PR DESCRIPTION
For some reason, they are sending to random members, and increase the load every time it is used. To avoid ratelimit exhaustion and spamming unfortunate people while we fix this, the PR will disable the feature for now.