### PR TITLE
Update reloader cog

### DIFF
--- a/futaba/cogs/filter/__init__.py
+++ b/futaba/cogs/filter/__init__.py
@@ -17,11 +17,21 @@ from .manage import add_filter, delete_filter, show_filter
 from .core import Filtering
 from .filter import Filter
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Filtering(bot)
+
+def setup_Filtering(bot):
     cog = Filtering(bot)
     bot.add_listener(cog.check_message, "on_message")
     bot.add_listener(cog.check_message_edit, "on_message_edit")
     bot.add_listener(cog.check_member_join, "on_member_join")
     bot.add_listener(cog.check_member_update, "on_member_update")
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Filtering(bot)
+
+def teardown_Filtering(bot):
+    bot.remove_cog(Filtering.__name__)

--- a/futaba/cogs/filter/__init__.py
+++ b/futaba/cogs/filter/__init__.py
@@ -21,6 +21,7 @@ from .filter import Filter
 def setup(bot):
     setup_Filtering(bot)
 
+
 def setup_Filtering(bot):
     cog = Filtering(bot)
     bot.add_listener(cog.check_message, "on_message")
@@ -29,9 +30,11 @@ def setup_Filtering(bot):
     bot.add_listener(cog.check_member_update, "on_member_update")
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Filtering(bot)
+
 
 def teardown_Filtering(bot):
     bot.remove_cog(Filtering.__name__)

--- a/futaba/cogs/filter/__init__.py
+++ b/futaba/cogs/filter/__init__.py
@@ -19,10 +19,10 @@ from .filter import Filter
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Filtering(bot)
+    setup_filtering(bot)
 
 
-def setup_Filtering(bot):
+def setup_filtering(bot):
     cog = Filtering(bot)
     bot.add_listener(cog.check_message, "on_message")
     bot.add_listener(cog.check_message_edit, "on_message_edit")
@@ -33,8 +33,8 @@ def setup_Filtering(bot):
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Filtering(bot)
+    teardown_filtering(bot)
 
 
-def teardown_Filtering(bot):
+def teardown_filtering(bot):
     bot.remove_cog(Filtering.__name__)

--- a/futaba/cogs/info/__init__.py
+++ b/futaba/cogs/info/__init__.py
@@ -13,11 +13,27 @@
 from .alias import Alias
 from .core import Info
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Info(bot)
+    setup_Alias(bot)
+
+def setup_Info(bot):
     cog = Info(bot)
     bot.add_cog(cog)
 
+def setup_Alias(bot):
     cog = Alias(bot)
     bot.add_listener(cog.member_update, "on_member_update")
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Info(bot)
+    teardown_Alias(bot)
+
+def teardown_Info(bot):
+    bot.remove_cog(Info.__name__)
+
+def teardown_Alias(bot):
+    bot.remove_cog(Alias.__name__)

--- a/futaba/cogs/info/__init__.py
+++ b/futaba/cogs/info/__init__.py
@@ -18,22 +18,27 @@ def setup(bot):
     setup_Info(bot)
     setup_Alias(bot)
 
+
 def setup_Info(bot):
     cog = Info(bot)
     bot.add_cog(cog)
+
 
 def setup_Alias(bot):
     cog = Alias(bot)
     bot.add_listener(cog.member_update, "on_member_update")
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Info(bot)
     teardown_Alias(bot)
 
+
 def teardown_Info(bot):
     bot.remove_cog(Info.__name__)
+
 
 def teardown_Alias(bot):
     bot.remove_cog(Alias.__name__)

--- a/futaba/cogs/info/__init__.py
+++ b/futaba/cogs/info/__init__.py
@@ -15,16 +15,16 @@ from .core import Info
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Info(bot)
-    setup_Alias(bot)
+    setup_info(bot)
+    setup_alias(bot)
 
 
-def setup_Info(bot):
+def setup_info(bot):
     cog = Info(bot)
     bot.add_cog(cog)
 
 
-def setup_Alias(bot):
+def setup_alias(bot):
     cog = Alias(bot)
     bot.add_listener(cog.member_update, "on_member_update")
     bot.add_cog(cog)
@@ -32,13 +32,13 @@ def setup_Alias(bot):
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Info(bot)
-    teardown_Alias(bot)
+    teardown_info(bot)
+    teardown_alias(bot)
 
 
-def teardown_Info(bot):
+def teardown_info(bot):
     bot.remove_cog(Info.__name__)
 
 
-def teardown_Alias(bot):
+def teardown_alias(bot):
     bot.remove_cog(Alias.__name__)

--- a/futaba/cogs/journal/__init__.py
+++ b/futaba/cogs/journal/__init__.py
@@ -14,18 +14,18 @@ from .core import Journal
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Journal(bot)
+    setup_journal(bot)
 
 
-def setup_Journal(bot):
+def setup_journal(bot):
     cog = Journal(bot)
     bot.add_cog(cog)
 
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Journal(bot)
+    teardown_journal(bot)
 
 
-def teardown_Reloader(bot):
+def teardown_journal(bot):
     bot.remove_cog(Journal.__name__)

--- a/futaba/cogs/journal/__init__.py
+++ b/futaba/cogs/journal/__init__.py
@@ -12,7 +12,17 @@
 
 from .core import Journal
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Journal(bot)
+
+def setup_Journal(bot):
     cog = Journal(bot)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Journal(bot)
+
+def teardown_Reloader(bot):
+    bot.remove_cog(Journal.__name__)

--- a/futaba/cogs/journal/__init__.py
+++ b/futaba/cogs/journal/__init__.py
@@ -16,13 +16,16 @@ from .core import Journal
 def setup(bot):
     setup_Journal(bot)
 
+
 def setup_Journal(bot):
     cog = Journal(bot)
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Journal(bot)
+
 
 def teardown_Reloader(bot):
     bot.remove_cog(Journal.__name__)

--- a/futaba/cogs/misc/__init__.py
+++ b/futaba/cogs/misc/__init__.py
@@ -16,22 +16,22 @@ from .mentionable import Mentionable
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Miscellaneous(bot)
-    setup_Debugging(bot)
-    setup_Mentionable(bot)
+    setup_miscellaneous(bot)
+    setup_debugging(bot)
+    setup_mentionable(bot)
 
 
-def setup_Miscellaneous(bot):
+def setup_miscellaneous(bot):
     cog = Miscellaneous(bot)
     bot.add_cog(cog)
 
 
-def setup_Debugging(bot):
+def setup_debugging(bot):
     cog = Debugging(bot)
     bot.add_cog(cog)
 
 
-def setup_Mentionable(bot):
+def setup_mentionable(bot):
     cog = Mentionable(bot)
     bot.add_listener(cog.member_join, "on_member_join")
     bot.add_listener(cog.member_update, "on_member_update")
@@ -40,18 +40,18 @@ def setup_Mentionable(bot):
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Miscellaneous(bot)
-    teardown_Debugging(bot)
-    teardown_Mentionable(bot)
+    teardown_miscellaneous(bot)
+    teardown_debugging(bot)
+    teardown_mentionable(bot)
 
 
-def teardown_Miscellaneous(bot):
+def teardown_miscellaneous(bot):
     bot.remove_cog(Miscellaneous.__name__)
 
 
-def teardown_Debugging(bot):
+def teardown_debugging(bot):
     bot.remove_cog(Debugging.__name__)
 
 
-def teardown_Mentionable(bot):
+def teardown_mentionable(bot):
     bot.remove_cog(Mentionable.__name__)

--- a/futaba/cogs/misc/__init__.py
+++ b/futaba/cogs/misc/__init__.py
@@ -14,15 +14,37 @@ from .core import Miscellaneous
 from .debug import Debugging
 from .mentionable import Mentionable
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Miscellaneous(bot)
+    setup_Debugging(bot)
+    setup_Mentionable(bot)
+
+def setup_Miscellaneous(bot):
     cog = Miscellaneous(bot)
     bot.add_cog(cog)
 
+def setup_Debugging(bot):
     cog = Debugging(bot)
     bot.add_cog(cog)
 
+def setup_Mentionable(bot):
     cog = Mentionable(bot)
     bot.add_listener(cog.member_join, "on_member_join")
     bot.add_listener(cog.member_update, "on_member_update")
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Miscellaneous(bot)
+    teardown_Debugging(bot)
+    teardown_Mentionable(bot)
+
+def teardown_Miscellaneous(bot):
+    bot.remove_cog(Miscellaneous.__name__)
+
+def teardown_Debugging(bot):
+    bot.remove_cog(Debugging.__name__)
+
+def teardown_Mentionable(bot):
+    bot.remove_cog(Mentionable.__name__)

--- a/futaba/cogs/misc/__init__.py
+++ b/futaba/cogs/misc/__init__.py
@@ -20,13 +20,16 @@ def setup(bot):
     setup_Debugging(bot)
     setup_Mentionable(bot)
 
+
 def setup_Miscellaneous(bot):
     cog = Miscellaneous(bot)
     bot.add_cog(cog)
 
+
 def setup_Debugging(bot):
     cog = Debugging(bot)
     bot.add_cog(cog)
+
 
 def setup_Mentionable(bot):
     cog = Mentionable(bot)
@@ -34,17 +37,21 @@ def setup_Mentionable(bot):
     bot.add_listener(cog.member_update, "on_member_update")
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Miscellaneous(bot)
     teardown_Debugging(bot)
     teardown_Mentionable(bot)
 
+
 def teardown_Miscellaneous(bot):
     bot.remove_cog(Miscellaneous.__name__)
 
+
 def teardown_Debugging(bot):
     bot.remove_cog(Debugging.__name__)
+
 
 def teardown_Mentionable(bot):
     bot.remove_cog(Mentionable.__name__)

--- a/futaba/cogs/moderation/__init__.py
+++ b/futaba/cogs/moderation/__init__.py
@@ -20,13 +20,16 @@ def setup(bot):
     setup_Moderation(bot)
     setup_ManualModActionWarn(bot)
 
+
 def setup_Cleanup(bot):
     cog = Cleanup(bot)
     bot.add_cog(cog)
 
+
 def setup_Moderation(bot):
     cog = Moderation(bot)
     bot.add_cog(cog)
+
 
 def setup_ManualModActionWarn(bot):
     cog = ManualModActionWarn(bot)
@@ -34,17 +37,21 @@ def setup_ManualModActionWarn(bot):
     bot.add_listener(cog.member_remove, "on_member_remove")
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Cleanup(bot)
     teardown_Moderation(bot)
     teardown_ManualModActionWarn(bot)
 
+
 def teardown_Cleanup(bot):
     bot.remove_cog(Cleanup.__name__)
 
+
 def teardown_Moderation(bot):
     bot.remove_cog(Moderation.__name__)
+
 
 def teardown_ManualModActionWarn(bot):
     bot.remove_cog(ManualModActionWarn.__name__)

--- a/futaba/cogs/moderation/__init__.py
+++ b/futaba/cogs/moderation/__init__.py
@@ -14,15 +14,37 @@ from .cleanup import Cleanup
 from .core import Moderation
 from .manual_mod_action_warn import ManualModActionWarn
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Cleanup(bot)
+    setup_Moderation(bot)
+    setup_ManualModActionWarn(bot)
+
+def setup_Cleanup(bot):
     cog = Cleanup(bot)
     bot.add_cog(cog)
 
+def setup_Moderation(bot):
     cog = Moderation(bot)
     bot.add_cog(cog)
 
+def setup_ManualModActionWarn(bot):
     cog = ManualModActionWarn(bot)
     bot.add_listener(cog.member_update, "on_member_update")
     bot.add_listener(cog.member_remove, "on_member_remove")
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Cleanup(bot)
+    teardown_Moderation(bot)
+    teardown_ManualModActionWarn(bot)
+
+def teardown_Cleanup(bot):
+    bot.remove_cog(Cleanup.__name__)
+
+def teardown_Moderation(bot):
+    bot.remove_cog(Moderation.__name__)
+
+def teardown_ManualModActionWarn(bot):
+    bot.remove_cog(ManualModActionWarn.__name__)

--- a/futaba/cogs/moderation/__init__.py
+++ b/futaba/cogs/moderation/__init__.py
@@ -16,22 +16,22 @@ from .manual_mod_action_warn import ManualModActionWarn
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Cleanup(bot)
-    setup_Moderation(bot)
-    setup_ManualModActionWarn(bot)
+    setup_cleanup(bot)
+    setup_moderation(bot)
+    setup_manualmodactionwarn(bot)
 
 
-def setup_Cleanup(bot):
+def setup_cleanup(bot):
     cog = Cleanup(bot)
     bot.add_cog(cog)
 
 
-def setup_Moderation(bot):
+def setup_moderation(bot):
     cog = Moderation(bot)
     bot.add_cog(cog)
 
 
-def setup_ManualModActionWarn(bot):
+def setup_manualmodactionwarn(bot):
     cog = ManualModActionWarn(bot)
     bot.add_listener(cog.member_update, "on_member_update")
     bot.add_listener(cog.member_remove, "on_member_remove")
@@ -40,18 +40,18 @@ def setup_ManualModActionWarn(bot):
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Cleanup(bot)
-    teardown_Moderation(bot)
-    teardown_ManualModActionWarn(bot)
+    teardown_cleanup(bot)
+    teardown_moderation(bot)
+    teardown_manualmodactionwarn(bot)
 
 
-def teardown_Cleanup(bot):
+def teardown_cleanup(bot):
     bot.remove_cog(Cleanup.__name__)
 
 
-def teardown_Moderation(bot):
+def teardown_moderation(bot):
     bot.remove_cog(Moderation.__name__)
 
 
-def teardown_ManualModActionWarn(bot):
+def teardown_manualmodactionwarn(bot):
     bot.remove_cog(ManualModActionWarn.__name__)

--- a/futaba/cogs/navi/__init__.py
+++ b/futaba/cogs/navi/__init__.py
@@ -16,13 +16,16 @@ from .core import Navi
 def setup(bot):
     setup_Navi(bot)
 
+
 def setup_Navi(bot):
     cog = Navi(bot)
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Navi(bot)
+
 
 def teardown_Navi(bot):
     bot.remove_cog(Navi.__name__)

--- a/futaba/cogs/navi/__init__.py
+++ b/futaba/cogs/navi/__init__.py
@@ -14,18 +14,18 @@ from .core import Navi
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Navi(bot)
+    setup_navi(bot)
 
 
-def setup_Navi(bot):
+def setup_navi(bot):
     cog = Navi(bot)
     bot.add_cog(cog)
 
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Navi(bot)
+    teardown_navi(bot)
 
 
-def teardown_Navi(bot):
+def teardown_navi(bot):
     bot.remove_cog(Navi.__name__)

--- a/futaba/cogs/navi/__init__.py
+++ b/futaba/cogs/navi/__init__.py
@@ -12,7 +12,17 @@
 
 from .core import Navi
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Navi(bot)
+
+def setup_Navi(bot):
     cog = Navi(bot)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Navi(bot)
+
+def teardown_Navi(bot):
+    bot.remove_cog(Navi.__name__)

--- a/futaba/cogs/optional/example/__init__.py
+++ b/futaba/cogs/optional/example/__init__.py
@@ -14,18 +14,18 @@ from .core import ExampleCog
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_ExampleCog(bot)
+    setup_examplecog(bot)
 
 
-def setup_ExampleCog(bot):
+def setup_examplecog(bot):
     cog = ExampleCog(bot)
     bot.add_cog(cog)
 
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_ExampleCog(bot)
+    teardown_examplecog(bot)
 
 
 def teardown_ExampleCog(bot):
-    bot.remove_cog(ExampleCog.__name__)
+    bot.remove_cog(examplecog.__name__)

--- a/futaba/cogs/optional/example/__init__.py
+++ b/futaba/cogs/optional/example/__init__.py
@@ -12,7 +12,17 @@
 
 from .core import ExampleCog
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_ExampleCog(bot)
+
+def setup_ExampleCog(bot):
     cog = ExampleCog(bot)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_ExampleCog(bot)
+
+def teardown_ExampleCog(bot):
+    bot.remove_cog(ExampleCog.__name__)

--- a/futaba/cogs/optional/example/__init__.py
+++ b/futaba/cogs/optional/example/__init__.py
@@ -16,13 +16,16 @@ from .core import ExampleCog
 def setup(bot):
     setup_ExampleCog(bot)
 
+
 def setup_ExampleCog(bot):
     cog = ExampleCog(bot)
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_ExampleCog(bot)
+
 
 def teardown_ExampleCog(bot):
     bot.remove_cog(ExampleCog.__name__)

--- a/futaba/cogs/optional/statbot/__init__.py
+++ b/futaba/cogs/optional/statbot/__init__.py
@@ -12,7 +12,17 @@
 
 from .core import Statbot
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Statbot(bot)
+
+def setup_Statbot(bot):
     cog = Statbot(bot)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Statbot(bot)
+
+def teardown_Statbot(bot):
+    bot.remove_cog(Statbot.__name__)

--- a/futaba/cogs/optional/statbot/__init__.py
+++ b/futaba/cogs/optional/statbot/__init__.py
@@ -16,13 +16,16 @@ from .core import Statbot
 def setup(bot):
     setup_Statbot(bot)
 
+
 def setup_Statbot(bot):
     cog = Statbot(bot)
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Statbot(bot)
+
 
 def teardown_Statbot(bot):
     bot.remove_cog(Statbot.__name__)

--- a/futaba/cogs/optional/statbot/__init__.py
+++ b/futaba/cogs/optional/statbot/__init__.py
@@ -14,18 +14,18 @@ from .core import Statbot
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Statbot(bot)
+    setup_statbot(bot)
 
 
-def setup_Statbot(bot):
+def setup_statbot(bot):
     cog = Statbot(bot)
     bot.add_cog(cog)
 
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Statbot(bot)
+    teardown_statbot(bot)
 
 
-def teardown_Statbot(bot):
+def teardown_statbot(bot):
     bot.remove_cog(Statbot.__name__)

--- a/futaba/cogs/reloader/__init__.py
+++ b/futaba/cogs/reloader/__init__.py
@@ -13,6 +13,17 @@
 from .core import Reloader
 
 
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Reloader(bot)
+
+def setup_Reloader(bot):
     cog = Reloader(bot)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Reloader(bot)
+
+def teardown_Reloader(bot):
+    bot.remove_cog(Reloader.__name__)

--- a/futaba/cogs/reloader/__init__.py
+++ b/futaba/cogs/reloader/__init__.py
@@ -17,13 +17,16 @@ from .core import Reloader
 def setup(bot):
     setup_Reloader(bot)
 
+
 def setup_Reloader(bot):
     cog = Reloader(bot)
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Reloader(bot)
+
 
 def teardown_Reloader(bot):
     bot.remove_cog(Reloader.__name__)

--- a/futaba/cogs/reloader/__init__.py
+++ b/futaba/cogs/reloader/__init__.py
@@ -15,18 +15,18 @@ from .core import Reloader
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Reloader(bot)
+    setup_reloader(bot)
 
 
-def setup_Reloader(bot):
+def setup_reloader(bot):
     cog = Reloader(bot)
     bot.add_cog(cog)
 
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Reloader(bot)
+    teardown_reloader(bot)
 
 
-def teardown_Reloader(bot):
+def teardown_reloader(bot):
     bot.remove_cog(Reloader.__name__)

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -49,13 +49,15 @@ class Reloader(AbstractCog):
         pass
 
     def load_cog(self, cogname):
-        if '.' in cogname:
-            ext_name, cogname = cogname.split('.', 1)
+        if "." in cogname:
+            ext_name, cogname = cogname.split(".", 1)
             if not ext_name.startswith(COGS_DIR):
                 ext_name = f"{COGS_DIR}{ext_name}"
 
             if ext_name in self.bot.extensions:
-                setup_function = getattr(self.bot.extensions[ext_name], f'setup_{cogname}')
+                setup_function = getattr(
+                    self.bot.extensions[ext_name], f"setup_{cogname}"
+                )
                 setup_function(self.bot)
         else:
             if not cogname.startswith(COGS_DIR):
@@ -63,15 +65,17 @@ class Reloader(AbstractCog):
             self.bot.load_extension(cogname)
 
     def unload_cog(self, cogname, check_missing=True):
-        if '.' in cogname:
-            ext_name, cogname = cogname.split('.', 1)
+        if "." in cogname:
+            ext_name, cogname = cogname.split(".", 1)
             if not ext_name.startswith(COGS_DIR):
                 ext_name = f"{COGS_DIR}{ext_name}"
 
             if ext_name in self.bot.extensions:
-                teardown_function = getattr(self.bot.extensions[ext_name], f'teardown_{cogname}')
+                teardown_function = getattr(
+                    self.bot.extensions[ext_name], f"teardown_{cogname}"
+                )
                 teardown_function(self.bot)
-        else:        
+        else:
             if not cogname.startswith(COGS_DIR):
                 cogname = f"{COGS_DIR}{cogname}"
             if check_missing:

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -56,7 +56,7 @@ class Reloader(AbstractCog):
 
             if ext_name in self.bot.extensions:
                 setup_function = getattr(
-                    self.bot.extensions[ext_name], f"setup_{cogname}"
+                    self.bot.extensions[ext_name], f"setup_{cogname.lower()}"
                 )
                 setup_function(self.bot)
         else:
@@ -72,7 +72,7 @@ class Reloader(AbstractCog):
 
             if ext_name in self.bot.extensions:
                 teardown_function = getattr(
-                    self.bot.extensions[ext_name], f"teardown_{cogname}"
+                    self.bot.extensions[ext_name], f"teardown_{cogname.lower()}"
                 )
                 teardown_function(self.bot)
         else:

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -49,17 +49,35 @@ class Reloader(AbstractCog):
         pass
 
     def load_cog(self, cogname):
-        if not cogname.startswith(COGS_DIR):
-            cogname = f"{COGS_DIR}{cogname}"
-        self.bot.load_extension(cogname)
+        if '.' in cogname:
+            ext_name, cogname = cogname.split('.', 1)
+            if not ext_name.startswith(COGS_DIR):
+                ext_name = f"{COGS_DIR}{ext_name}"
+
+            if ext_name in self.bot.extensions:
+                setup_function = getattr(self.bot.extensions[ext_name], f'setup_{cogname}')
+                setup_function(self.bot)
+        else:
+            if not cogname.startswith(COGS_DIR):
+                cogname = f"{COGS_DIR}{cogname}"
+            self.bot.load_extension(cogname)
 
     def unload_cog(self, cogname, check_missing=True):
-        if not cogname.startswith(COGS_DIR):
-            cogname = f"{COGS_DIR}{cogname}"
-        if check_missing:
-            if importlib.util.find_spec(cogname) is None:
-                raise KeyError(f"No such cog: {cogname}")
-        self.bot.unload_extension(cogname)
+        if '.' in cogname:
+            ext_name, cogname = cogname.split('.', 1)
+            if not ext_name.startswith(COGS_DIR):
+                ext_name = f"{COGS_DIR}{ext_name}"
+
+            if ext_name in self.bot.extensions:
+                teardown_function = getattr(self.bot.extensions[ext_name], f'teardown_{cogname}')
+                teardown_function(self.bot)
+        else:        
+            if not cogname.startswith(COGS_DIR):
+                cogname = f"{COGS_DIR}{cogname}"
+            if check_missing:
+                if importlib.util.find_spec(cogname) is None:
+                    raise KeyError(f"No such cog: {cogname}")
+            self.bot.unload_extension(cogname)
 
     @commands.command(name="load", aliases=["l"])
     @permissions.check_owner()

--- a/futaba/cogs/roles/__init__.py
+++ b/futaba/cogs/roles/__init__.py
@@ -14,18 +14,18 @@ from .core import SelfAssignableRoles
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_SelfAssignableRoles(bot)
+    setup_selfassignableroles(bot)
 
 
-def setup_SelfAssignableRoles(bot):
+def setup_selfassignableroles(bot):
     cog = SelfAssignableRoles(bot)
     bot.add_cog(cog)
 
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_SelfAssignableRoles(bot)
+    teardown_selfassignableroles(bot)
 
 
-def teardown_SelfAssignableRoles(bot):
+def teardown_selfassignableroles(bot):
     bot.remove_cog(SelfAssignableRoles.__name__)

--- a/futaba/cogs/roles/__init__.py
+++ b/futaba/cogs/roles/__init__.py
@@ -12,7 +12,17 @@
 
 from .core import SelfAssignableRoles
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_SelfAssignableRoles(bot)
+
+def setup_SelfAssignableRoles(bot):
     cog = SelfAssignableRoles(bot)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_SelfAssignableRoles(bot)
+
+def teardown_SelfAssignableRoles(bot):
+    bot.remove_cog(SelfAssignableRoles.__name__)

--- a/futaba/cogs/roles/__init__.py
+++ b/futaba/cogs/roles/__init__.py
@@ -16,13 +16,16 @@ from .core import SelfAssignableRoles
 def setup(bot):
     setup_SelfAssignableRoles(bot)
 
+
 def setup_SelfAssignableRoles(bot):
     cog = SelfAssignableRoles(bot)
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_SelfAssignableRoles(bot)
+
 
 def teardown_SelfAssignableRoles(bot):
     bot.remove_cog(SelfAssignableRoles.__name__)

--- a/futaba/cogs/settings/__init__.py
+++ b/futaba/cogs/settings/__init__.py
@@ -16,13 +16,16 @@ from .core import Settings
 def setup(bot):
     setup_Settings(bot)
 
+
 def setup_Settings(bot):
     cog = Settings(bot)
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Settings(bot)
+
 
 def teardown_Settings(bot):
     bot.remove_cog(Settings.__name__)

--- a/futaba/cogs/settings/__init__.py
+++ b/futaba/cogs/settings/__init__.py
@@ -14,18 +14,18 @@ from .core import Settings
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Settings(bot)
+    setup_settings(bot)
 
 
-def setup_Settings(bot):
+def setup_settings(bot):
     cog = Settings(bot)
     bot.add_cog(cog)
 
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Settings(bot)
+    teardown_settings(bot)
 
 
-def teardown_Settings(bot):
+def teardown_settings(bot):
     bot.remove_cog(Settings.__name__)

--- a/futaba/cogs/settings/__init__.py
+++ b/futaba/cogs/settings/__init__.py
@@ -12,7 +12,17 @@
 
 from .core import Settings
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Settings(bot)
+
+def setup_Settings(bot):
     cog = Settings(bot)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Settings(bot)
+
+def teardown_Settings(bot):
+    bot.remove_cog(Settings.__name__)

--- a/futaba/cogs/tracker/__init__.py
+++ b/futaba/cogs/tracker/__init__.py
@@ -12,9 +12,19 @@
 
 from .core import Tracker, LISTENERS, get_removal_cause
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Tracker(bot)
+
+def setup_Tracker(bot):
     cog = Tracker(bot)
     for listener in LISTENERS:
         bot.add_listener(getattr(cog, listener), listener)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Tracker(bot)
+
+def teardown_Tracker(bot):
+    bot.remove_cog(Tracker.__name__)

--- a/futaba/cogs/tracker/__init__.py
+++ b/futaba/cogs/tracker/__init__.py
@@ -16,15 +16,18 @@ from .core import Tracker, LISTENERS, get_removal_cause
 def setup(bot):
     setup_Tracker(bot)
 
+
 def setup_Tracker(bot):
     cog = Tracker(bot)
     for listener in LISTENERS:
         bot.add_listener(getattr(cog, listener), listener)
     bot.add_cog(cog)
 
+
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
     teardown_Tracker(bot)
+
 
 def teardown_Tracker(bot):
     bot.remove_cog(Tracker.__name__)

--- a/futaba/cogs/tracker/__init__.py
+++ b/futaba/cogs/tracker/__init__.py
@@ -14,10 +14,10 @@ from .core import Tracker, LISTENERS, get_removal_cause
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Tracker(bot)
+    setup_tracker(bot)
 
 
-def setup_Tracker(bot):
+def setup_tracker(bot):
     cog = Tracker(bot)
     for listener in LISTENERS:
         bot.add_listener(getattr(cog, listener), listener)
@@ -26,8 +26,8 @@ def setup_Tracker(bot):
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Tracker(bot)
+    teardown_tracker(bot)
 
 
-def teardown_Tracker(bot):
+def teardown_tracker(bot):
     bot.remove_cog(Tracker.__name__)

--- a/futaba/cogs/welcome/__init__.py
+++ b/futaba/cogs/welcome/__init__.py
@@ -16,18 +16,18 @@ from .prune import Prune
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_Alert(bot)
-    setup_Welcome(bot)
-    setup_Prune(bot)
+    setup_alert(bot)
+    setup_welcome(bot)
+    setup_prune(bot)
 
 
-def setup_Alert(bot):
+def setup_alert(bot):
     cog = Alert(bot)
     bot.add_listener(cog.member_join, "on_member_join")
     bot.add_cog(cog)
 
 
-def setup_Welcome(bot):
+def setup_welcome(bot):
     cog = Welcome(bot)
     bot.add_listener(cog.member_join, "on_member_join")
     bot.add_listener(cog.member_update, "on_member_update")
@@ -35,25 +35,25 @@ def setup_Welcome(bot):
     bot.add_cog(cog)
 
 
-def setup_Prune(bot):
+def setup_prune(bot):
     cog = Prune(bot)
     bot.add_cog(cog)
 
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_Alert(bot)
-    teardown_Welcome(bot)
-    teardown_Prune(bot)
+    teardown_alert(bot)
+    teardown_welcome(bot)
+    teardown_prune(bot)
 
 
-def teardown_Alert(bot):
+def teardown_alert(bot):
     bot.remove_cog(Alert.__name__)
 
 
-def teardown_Welcome(bot):
+def teardown_welcome(bot):
     bot.remove_cog(Welcome.__name__)
 
 
-def teardown_Prune(bot):
+def teardown_prune(bot):
     bot.remove_cog(Prune.__name__)

--- a/futaba/cogs/welcome/__init__.py
+++ b/futaba/cogs/welcome/__init__.py
@@ -14,17 +14,39 @@ from .alert import Alert
 from .core import Welcome
 from .prune import Prune
 
-
+# Setup for when cog is loaded
 def setup(bot):
+    setup_Alert(bot)
+    setup_Welcome(bot)
+    setup_Prune(bot)
+
+def setup_Alert(bot):
     cog = Alert(bot)
     bot.add_listener(cog.member_join, "on_member_join")
     bot.add_cog(cog)
 
+def setup_Welcome(bot):
     cog = Welcome(bot)
     bot.add_listener(cog.member_join, "on_member_join")
     bot.add_listener(cog.member_update, "on_member_update")
     bot.add_listener(cog.member_leave, "on_member_remove")
     bot.add_cog(cog)
 
+def setup_Prune(bot):
     cog = Prune(bot)
     bot.add_cog(cog)
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_Alert(bot)
+    teardown_Welcome(bot)
+    teardown_Prune(bot)
+
+def teardown_Alert(bot):
+    bot.remove_cog(Alert.__name__)
+
+def teardown_Welcome(bot):
+    bot.remove_cog(Welcome.__name__)
+
+def teardown_Prune(bot):
+    bot.remove_cog(Prune.__name__)

--- a/futaba/cogs/welcome/__init__.py
+++ b/futaba/cogs/welcome/__init__.py
@@ -20,10 +20,12 @@ def setup(bot):
     setup_Welcome(bot)
     setup_Prune(bot)
 
+
 def setup_Alert(bot):
     cog = Alert(bot)
     bot.add_listener(cog.member_join, "on_member_join")
     bot.add_cog(cog)
+
 
 def setup_Welcome(bot):
     cog = Welcome(bot)
@@ -32,9 +34,11 @@ def setup_Welcome(bot):
     bot.add_listener(cog.member_leave, "on_member_remove")
     bot.add_cog(cog)
 
+
 def setup_Prune(bot):
     cog = Prune(bot)
     bot.add_cog(cog)
+
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
@@ -42,11 +46,14 @@ def teardown(bot):
     teardown_Welcome(bot)
     teardown_Prune(bot)
 
+
 def teardown_Alert(bot):
     bot.remove_cog(Alert.__name__)
 
+
 def teardown_Welcome(bot):
     bot.remove_cog(Welcome.__name__)
+
 
 def teardown_Prune(bot):
     bot.remove_cog(Prune.__name__)

--- a/futaba/sql/models/moderation.py
+++ b/futaba/sql/models/moderation.py
@@ -161,7 +161,7 @@ class ModerationModel:
             return KeyError(member)
 
         other_roles = []
-        other_role_ids, = result.fetchone()
+        (other_role_ids,) = result.fetchone()
         for role_id in other_role_ids:
             role = discord.utils.get(member.guild.roles, id=role_id)
             if role is not None:

--- a/futaba/sql/models/navi.py
+++ b/futaba/sql/models/navi.py
@@ -129,7 +129,7 @@ class NaviModel:
             parameters=task.build_parameters(),
         )
         result = self.sql.execute(ins)
-        task.id, = result.inserted_primary_key
+        (task.id,) = result.inserted_primary_key
 
     def remove_task(self, task):
         logger.info("Deleting task id %d", task.id)

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -211,9 +211,13 @@ class SettingsModel:
         if not result.rowcount:
             self.add_guild_settings(guild)
 
-        prefix, max_delete_messages, warn_manual_mod_action, remove_other_roles, mentionable_name_prefix = (
-            result.fetchone()
-        )
+        (
+            prefix,
+            max_delete_messages,
+            warn_manual_mod_action,
+            remove_other_roles,
+            mentionable_name_prefix,
+        ) = result.fetchone()
         self.guild_settings_cache[guild] = GuildSettingsData(
             prefix,
             max_delete_messages,

--- a/futaba/sql/models/welcome.py
+++ b/futaba/sql/models/welcome.py
@@ -239,7 +239,7 @@ class WelcomeModel:
             guild_id=guild.id, alert_key=alert.key, op=alert.op, value=str(alert.value)
         )
         result = self.sql.execute(ins)
-        alert.id, = result.inserted_primary_key
+        (alert.id,) = result.inserted_primary_key
 
     def get_all_alerts(self, guild):
         logger.info("Getting all join alerts for guild '%s' (%d)", guild.name, guild.id)


### PR DESCRIPTION
Hello and welcome to the first episode of Maware's wacky PR Corner.
This is a brand new series that only airs whenever I can be bother to code.

In this episode we have a brand new reloader cog which is a part of the dynamic cogs update.
This new cog allows you unload / load / reload sub cogs e.g the Miscellaneous sub cog that is apart of the misc cog.

All files cog have been updated to work with this new feature.

The way it work is by having a new setup and teardown function in `__init.py__` in all cogs for each sub cog (e.g. `setup_Miscellaneous` and `teardown_Miscellaneous`) which handles the loading and unloading of that sub cog. In addition we have a normal `setup` and `teardown` function that contains all sub cog setups and teardowns for when the cog is loaded / unloaded.

Example:
![image](https://user-images.githubusercontent.com/18365785/73137583-a1d76d00-4051-11ea-8d33-b7dde86986dd.png)

Anyways that's all for today's episode of Maware's wacky PR Corner.
Tune in next time (whenever that is) for hopefully the dynamic cogs update.