### PR TITLE
Fix reloader

### DIFF
--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -94,7 +94,7 @@ class Filtering(AbstractCog):
             # Guild filter-immune users
             sql.fetch_filter_immune_users(guild)
 
-    def __unload(self):
+    def cog_unload(self):
         """
         Remove listeners when unloading the cog.
         """

--- a/futaba/cogs/optional/example/__init__.py
+++ b/futaba/cogs/optional/example/__init__.py
@@ -14,10 +14,10 @@ from .core import ExampleCog
 
 # Setup for when cog is loaded
 def setup(bot):
-    setup_examplecog(bot)
+    setup_example(bot)
 
 
-def setup_examplecog(bot):
+def setup_example(bot):
     cog = ExampleCog(bot)
     bot.add_cog(cog)
 
@@ -27,5 +27,5 @@ def teardown(bot):
     teardown_examplecog(bot)
 
 
-def teardown_ExampleCog(bot):
-    bot.remove_cog(examplecog.__name__)
+def teardown_example(bot):
+    bot.remove_cog(ExampleCog.__name__)

--- a/futaba/cogs/optional/example/__init__.py
+++ b/futaba/cogs/optional/example/__init__.py
@@ -24,7 +24,7 @@ def setup_example(bot):
 
 # Remove all the cogs when cog is unloaded
 def teardown(bot):
-    teardown_examplecog(bot)
+    teardown_example(bot)
 
 
 def teardown_example(bot):

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -69,7 +69,7 @@ class Reloader(AbstractCog):
                     setup_function(self.bot)
             except (AttributeError, ModuleNotFoundError) as error:
                 raise KeyError(
-                    f"Failed to unload submodule {cogname} of module {ext_name}."
+                    f"Failed to load submodule {cogname} of module {ext_name}."
                 )
             except Exception as error:
                 raise error

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -85,8 +85,6 @@ class Reloader(AbstractCog):
             fixed_cogname = f"{COGS_DIR}{input_cogname}"
         if "." in input_cogname:
             ext_name, cogname = fixed_cogname.rsplit(".", 1)
-            if not ext_name.startswith(COGS_DIR):
-                ext_name = f"{COGS_DIR}{ext_name}"
             try:
                 try:
                     teardown_function = getattr(
@@ -251,7 +249,7 @@ class Reloader(AbstractCog):
 
         try:
             self.unload_cog(cogname, check_missing=False)
-            self.load_cog(cogname)
+            self.load_cog(cogname, check_missing=False)
         except Exception as error:
             logger.error("Reloading cog %s failed", cogname, exc_info=error)
             embed = discord.Embed(

--- a/futaba/cogs/reloader/core.py
+++ b/futaba/cogs/reloader/core.py
@@ -48,40 +48,69 @@ class Reloader(AbstractCog):
     def setup(self):
         pass
 
-    def load_cog(self, cogname):
-        if "." in cogname:
-            ext_name, cogname = cogname.split(".", 1)
-            if not ext_name.startswith(COGS_DIR):
-                ext_name = f"{COGS_DIR}{ext_name}"
-
-            if ext_name in self.bot.extensions:
-                setup_function = getattr(
-                    self.bot.extensions[ext_name], f"setup_{cogname.lower()}"
+    def load_cog(self, input_cogname, check_missing=True):
+        fixed_cogname = input_cogname
+        if not input_cogname.startswith(COGS_DIR):
+            fixed_cogname = f"{COGS_DIR}{input_cogname}"
+        if "." in input_cogname:
+            ext_name, cogname = fixed_cogname.rsplit(".", 1)
+            try:
+                try:
+                    setup_function = getattr(
+                        importlib.import_module(f"{ext_name}.{cogname}"),
+                        f"setup_{cogname.lower()}",
+                    )
+                    setup_function(self.bot)
+                except (AttributeError, ModuleNotFoundError) as error:
+                    setup_function = getattr(
+                        importlib.import_module(f"{ext_name}"),
+                        f"setup_{cogname.lower()}",
+                    )
+                    setup_function(self.bot)
+            except (AttributeError, ModuleNotFoundError) as error:
+                raise KeyError(
+                    f"Failed to unload submodule {cogname} of module {ext_name}."
                 )
-                setup_function(self.bot)
+            except Exception as error:
+                raise error
         else:
-            if not cogname.startswith(COGS_DIR):
-                cogname = f"{COGS_DIR}{cogname}"
-            self.bot.load_extension(cogname)
-
-    def unload_cog(self, cogname, check_missing=True):
-        if "." in cogname:
-            ext_name, cogname = cogname.split(".", 1)
-            if not ext_name.startswith(COGS_DIR):
-                ext_name = f"{COGS_DIR}{ext_name}"
-
-            if ext_name in self.bot.extensions:
-                teardown_function = getattr(
-                    self.bot.extensions[ext_name], f"teardown_{cogname.lower()}"
-                )
-                teardown_function(self.bot)
-        else:
-            if not cogname.startswith(COGS_DIR):
-                cogname = f"{COGS_DIR}{cogname}"
             if check_missing:
-                if importlib.util.find_spec(cogname) is None:
-                    raise KeyError(f"No such cog: {cogname}")
-            self.bot.unload_extension(cogname)
+                if importlib.util.find_spec(fixed_cogname) is None:
+                    raise KeyError(f"No such cog: {fixed_cogname}")
+            self.bot.load_extension(fixed_cogname)
+
+    def unload_cog(self, input_cogname, check_missing=True):
+        fixed_cogname = input_cogname
+        if not input_cogname.startswith(COGS_DIR):
+            fixed_cogname = f"{COGS_DIR}{input_cogname}"
+        if "." in input_cogname:
+            ext_name, cogname = fixed_cogname.rsplit(".", 1)
+            if not ext_name.startswith(COGS_DIR):
+                ext_name = f"{COGS_DIR}{ext_name}"
+            try:
+                try:
+                    teardown_function = getattr(
+                        importlib.import_module(f"{ext_name}.{cogname}"),
+                        f"teardown_{cogname.lower()}",
+                    )
+                    teardown_function(self.bot)
+                except (AttributeError, ModuleNotFoundError) as error:
+                    teardown_function = getattr(
+                        importlib.import_module(f"{ext_name}"),
+                        f"teardown_{cogname.lower()}",
+                    )
+                    teardown_function(self.bot)
+            except (AttributeError, ModuleNotFoundError) as error:
+                raise KeyError(
+                    f"Failed to unload submodule {cogname} of module {ext_name}. (Is it already unloaded?)"
+                )
+            except Exception as error:
+                raise error
+        else:
+            if check_missing:
+                if importlib.util.find_spec(fixed_cogname) is None:
+                    raise KeyError(f"No such cog: {fixed_cogname}")
+            self.bot.unload_extension(fixed_cogname)
 
     @commands.command(name="load", aliases=["l"])
     @permissions.check_owner()

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -127,7 +127,7 @@ class Tracker(AbstractCog):
     def setup(self):
         pass
 
-    def __unload(self):
+    def cog_unload(self):
         """
         Remove listeners when unloading the cog.
         """


### PR DESCRIPTION
Allows one to load or unload a cog whether or not it's a root cog, sub-cog, in the root folder, or in a separate folder. Also provides more detailed error messages for loading/unloading cogs.