### PR TITLE
Add converters for dual-IDs

### DIFF
--- a/futaba/converters/channel.py
+++ b/futaba/converters/channel.py
@@ -18,7 +18,7 @@ from discord.ext.commands import BadArgument, Converter
 
 from futaba.unicode import normalize_caseless
 
-from .utils import ID_REGEX
+from .utils import DUAL_ID_REGEX, ID_REGEX
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,13 @@ CHANNEL_MENTION_REGEX = re.compile(r"<#([0-9]+)>")
 
 async def get_channel(bot, argument):
     argument = normalize_caseless(argument)
+
+    # Checking if it's a dual ID
+    match = DUAL_ID_REGEX.match(argument)
+    if match is not None:
+        chan = bot.get_channel(int(match[1]))
+        if chan is not None:
+            return chan
 
     # Checking if it's a channel id
     match = ID_REGEX.match(argument)

--- a/futaba/converters/message.py
+++ b/futaba/converters/message.py
@@ -19,7 +19,7 @@ from discord.ext.commands import BadArgument, Converter
 
 from futaba.utils import first
 
-from .utils import ID_REGEX
+from .utils import DUAL_ID_REGEX, ID_REGEX
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +33,18 @@ JUMP_LINK_REGEX = re.compile(
 class MessageConv(Converter):
     @staticmethod
     def get_channels_and_id(ctx, argument):
+        # Checking if it's a dual ID
+        match = DUAL_ID_REGEX.match(argument)
+        if match is not None:
+            channel_id = int(match[1])
+            message_id = int(match[2])
+
+            channel = ctx.guild.get_channel(channel_id)
+            if channel is None:
+                return BadArgument(f"No channel found in guild with ID {channel_id}")
+
+            return [channel], message_id
+
         # Checking if it's an id
         match = ID_REGEX.match(argument)
         if match is not None:

--- a/futaba/converters/utils.py
+++ b/futaba/converters/utils.py
@@ -15,3 +15,4 @@ import re
 __all__ = ["ID_REGEX"]
 
 ID_REGEX = re.compile(r"([0-9]{15,21})$")
+DUAL_ID_REGEX = re.compile(r"([0-9]{15,21})-([0-9]{15,21})$")


### PR DESCRIPTION
Discord recently added a feature where if you hold "shift" while clicking "copy id" you get a string of the following form:
```
350516713443272192-675839352282854986
```
where the first value is the channel ID and the second is the message ID.

This PR adds support for this string to message and channel converters. In the case of the former, this enables a more efficient search by querying the respective channel directly.

![image](https://user-images.githubusercontent.com/8848022/74093683-3f478d80-4aa3-11ea-9bdb-a8b737934056.png)
