### PR TITLE
Add JWT generation command in new Authentication cog

### DIFF
--- a/futaba/client.py
+++ b/futaba/client.py
@@ -309,7 +309,9 @@ class Bot(commands.AutoShardedBot):
                 ctx.send(embed=embed), Reactions.MISSING.add(ctx.message)
             )
 
-        elif isinstance(error, (commands.errors.BadArgument, commands.errors.BadUnionArgument)):
+        elif isinstance(
+            error, (commands.errors.BadArgument, commands.errors.BadUnionArgument)
+        ):
             # Tell the user they couldn't find what they were looking for
             logger.info("User specified argument that does not compute")
 

--- a/futaba/cogs/auth/__init__.py
+++ b/futaba/cogs/auth/__init__.py
@@ -1,0 +1,31 @@
+#
+# cogs/settings/__init__.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2019 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+from .core import Authentication
+
+# Setup for when cog is loaded
+def setup(bot):
+    setup_auth(bot)
+
+
+def setup_auth(bot):
+    cog = Authentication(bot)
+    bot.add_cog(cog)
+
+
+# Remove all the cogs when cog is unloaded
+def teardown(bot):
+    teardown_auth(bot)
+
+
+def teardown_auth(bot):
+    bot.remove_cog(Authentication.__name__)

--- a/futaba/cogs/auth/__init__.py
+++ b/futaba/cogs/auth/__init__.py
@@ -1,5 +1,5 @@
 #
-# cogs/settings/__init__.py
+# cogs/auth/__init__.py
 #
 # futaba - A Discord Mod bot for the Programming server
 # Copyright (c) 2017-2019 Jake Richardson, Ammon Smith, jackylam5

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -50,7 +50,7 @@ class Authentication(AbstractCog):
                 "iss": f"futaba-{ctx.guild.id}",
                 "did": ctx.author.id,
                 "dnn": ctx.author.display_name,
-                "jdt": int((ctx.author.joined_at - epoch).total_seconds()),
+                "jdt": int((ctx.author.joined_at - epoch).total_seconds() * 1000),
                 "iat": int(time.time()),
             },
             self.jwt_secret,

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["Authentication"]
 
-
 class Authentication(AbstractCog):
     __slots__ = ("journal",)
 

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -16,6 +16,7 @@ Cog for authentication schemes and token generation
 
 import logging
 import time
+from datetime import datetime
 from jose import jwt
 
 import discord
@@ -47,6 +48,7 @@ class Authentication(AbstractCog):
                 "iss": f"futaba-{ctx.guild.id}",
                 "did": ctx.author.id,
                 "dnn": ctx.author.display_name,
+                "jdt": ctx.author.joined_at.time()
                 "iat": int(time.time()),
             },
             self.jwt_secret,

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["Authentication"]
 
+
 class Authentication(AbstractCog):
     __slots__ = ("journal",)
 
@@ -42,18 +43,19 @@ class Authentication(AbstractCog):
     async def jwt(self, ctx):
         """ Generates a Javascript Web Token for a user """
 
-        token = jwt.encode({"iss": f"futaba-{ctx.guild.id}", "did": ctx.author.id, "dnn": ctx.author.display_name, "iat": int(time.time())},
-                           self.jwt_secret,
-                           algorithm="HS256")
-
-        logger.info(
-            "User '%s' (%d) generated a JWT",
-            ctx.author.name,
-            ctx.author.id
+        token = jwt.encode(
+            {
+                "iss": f"futaba-{ctx.guild.id}",
+                "did": ctx.author.id,
+                "dnn": ctx.author.display_name,
+                "iat": int(time.time()),
+            },
+            self.jwt_secret,
+            algorithm="HS256",
         )
 
-        response = (
-            f"Generated authentication token: ```{token}```"
-        )
+        logger.info("User '%s' (%d) generated a JWT", ctx.author.name, ctx.author.id)
+
+        response = f"Generated authentication token: ```{token}```"
 
         await ctx.author.send(content=response)

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -48,7 +48,7 @@ class Authentication(AbstractCog):
                 "iss": f"futaba-{ctx.guild.id}",
                 "did": ctx.author.id,
                 "dnn": ctx.author.display_name,
-                "jdt": ctx.author.joined_at.time()
+                "jdt": ctx.author.joined_at.time(),
                 "iat": int(time.time()),
             },
             self.jwt_secret,

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -21,11 +21,6 @@ from jose import jwt
 import discord
 from discord.ext import commands
 
-from futaba.download import download_links
-from futaba.exceptions import CommandFailed
-from futaba.str_builder import StringBuilder
-from futaba.unicode import unicode_repr
-from futaba.utils import URL_REGEX
 from ..abc import AbstractCog
 
 logger = logging.getLogger(__name__)

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -1,5 +1,5 @@
 #
-# cogs/misc/core.py
+# cogs/auth/core.py
 #
 # futaba - A Discord Mod bot for the Programming server
 # Copyright (c) 2017-2019 Jake Richardson, Ammon Smith, jackylam5

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -15,6 +15,7 @@ Cog for authentication schemes and token generation
 """
 
 import logging
+import time
 from jose import jwt
 
 import discord
@@ -46,7 +47,7 @@ class Authentication(AbstractCog):
     async def jwt(self, ctx):
         """ Generates a Javascript Web Token for a user """
 
-        token = jwt.encode({"iss": f"futaba-{ctx.guild.id}", "did": ctx.author.id, "dnn": ctx.author.display_name},
+        token = jwt.encode({"iss": f"futaba-{ctx.guild.id}", "did": ctx.author.id, "dnn": ctx.author.display_name, "iat": int(time.time())},
                            self.jwt_secret,
                            algorithm="HS256")
 

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -60,4 +60,4 @@ class Authentication(AbstractCog):
             f"Generated authentication token: ```{token}```"
         )
 
-        ctx.author.send(content=response)
+        await ctx.author.send(content=response)

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -43,12 +43,14 @@ class Authentication(AbstractCog):
     async def jwt(self, ctx):
         """ Generates a Javascript Web Token for a user """
 
+        epoch = datetime.utcfromtimestamp(0)
+        
         token = jwt.encode(
             {
                 "iss": f"futaba-{ctx.guild.id}",
                 "did": ctx.author.id,
                 "dnn": ctx.author.display_name,
-                "jdt": int(ctx.author.joined_at.time()),
+                "jdt": int((ctx.author.joined_at - epoch).total_seconds() * 1000),
                 "iat": int(time.time()),
             },
             self.jwt_secret,

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -48,7 +48,7 @@ class Authentication(AbstractCog):
                 "iss": f"futaba-{ctx.guild.id}",
                 "did": ctx.author.id,
                 "dnn": ctx.author.display_name,
-                "jdt": ctx.author.joined_at.time(),
+                "jdt": int(ctx.author.joined_at.time()),
                 "iat": int(time.time()),
             },
             self.jwt_secret,

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -1,0 +1,66 @@
+#
+# cogs/misc/core.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2019 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+"""
+Cog for authentication schemes and token generation
+"""
+
+import logging
+from jwcrypto import jwt
+
+import discord
+from discord.ext import commands
+
+from futaba.download import download_links
+from futaba.exceptions import CommandFailed
+from futaba.str_builder import StringBuilder
+from futaba.unicode import unicode_repr
+from futaba.utils import URL_REGEX
+from ..abc import AbstractCog
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["Authentication"]
+
+class Authentication(AbstractCog):
+    __slots__ = ("journal",)
+
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.journal = bot.get_broadcaster("/auth")
+        self.jwt_secret = bot.config.jwt_secret
+
+    def setup(self):
+        pass
+
+    @commands.command(name="jwt", aliases=["dauth", "mcauth"])
+    async def jwt(self, ctx):
+        """ Generates a Javascript Web Token for a user """
+
+        token = jwt.JWT(header={"alg": "HS256", "typ": "JWT"},
+                        claims={"iss": "futaba", "sub": "lilim-mc", "did": ctx.author.id, "dnn": ctx.author.display_name},
+                        default_claims={"iat": None})
+        
+        token.make_signed_token(self.jwt_secret)
+        serialized = token.serialize()
+
+        logger.info(
+            "User '%s' (%d) generated a JWT",
+            ctx.author.name,
+            ctx.author.id
+        )
+
+        response = (
+            f"Generated authentication token: ```{serialized}```"
+        )
+
+        ctx.author.send(content=response)

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -15,7 +15,7 @@ Cog for authentication schemes and token generation
 """
 
 import logging
-from jwcrypto import jwt
+from jose import jwt
 
 import discord
 from discord.ext import commands
@@ -46,12 +46,9 @@ class Authentication(AbstractCog):
     async def jwt(self, ctx):
         """ Generates a Javascript Web Token for a user """
 
-        token = jwt.JWT(header={"alg": "HS256", "typ": "JWT"},
-                        claims={"iss": "futaba", "sub": "lilim-mc", "did": ctx.author.id, "dnn": ctx.author.display_name},
-                        default_claims={"iat": None})
-        
-        token.make_signed_token(self.jwt_secret)
-        serialized = token.serialize()
+        token = jwt.encode({"iss": f"futaba-{ctx.guild.id}", "did": ctx.author.id, "dnn": ctx.author.display_name},
+                           self.jwt_secret,
+                           algorithm="HS256")
 
         logger.info(
             "User '%s' (%d) generated a JWT",
@@ -60,7 +57,7 @@ class Authentication(AbstractCog):
         )
 
         response = (
-            f"Generated authentication token: ```{serialized}```"
+            f"Generated authentication token: ```{token}```"
         )
 
         ctx.author.send(content=response)

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -50,7 +50,7 @@ class Authentication(AbstractCog):
                 "iss": f"futaba-{ctx.guild.id}",
                 "did": ctx.author.id,
                 "dnn": ctx.author.display_name,
-                "jdt": int((ctx.author.joined_at - epoch).total_seconds() * 1000),
+                "jdt": int((ctx.author.joined_at - epoch).total_seconds()),
                 "iat": int(time.time()),
             },
             self.jwt_secret,

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -74,7 +74,7 @@ Configuration = namedtuple(
         "python_emoji_id",
         "discord_py_emoji_id",
         "database_url",
-        "jwt_secret"
+        "jwt_secret",
     ),
 )
 

--- a/futaba/config.py
+++ b/futaba/config.py
@@ -55,6 +55,7 @@ ConfigurationSchema = Schema(
             "discordpy": Or(And(str, ID_REGEX.match), "0"),
         },
         "database": {"url": And(str, len)},
+        "jwt": {"secret": And(str, len)},
     }
 )
 
@@ -73,6 +74,7 @@ Configuration = namedtuple(
         "python_emoji_id",
         "discord_py_emoji_id",
         "database_url",
+        "jwt_secret"
     ),
 )
 
@@ -96,4 +98,5 @@ def load_config(path):
         python_emoji_id=int(config["emojis"]["python"]),
         discord_py_emoji_id=int(config["emojis"]["discordpy"]),
         database_url=config["database"]["url"],
+        jwt_secret=config["jwt"]["secret"],
     )

--- a/misc/config.toml
+++ b/misc/config.toml
@@ -45,3 +45,6 @@ discordpy = "490419059964510210"
 # Path to the RDBMS futaba will use
 [database]
 url = "sqlite:///futaba.db"
+
+[jwt]
+secret = "thesecretstring"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ schema>=0.6
 textdistance>=3.0
 toml>=0.9
 tree-format>=0.1.2
-jose>=1.0.0
+python-jose>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ schema>=0.6
 textdistance>=3.0
 toml>=0.9
 tree-format>=0.1.2
+jwcrypto>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ schema>=0.6
 textdistance>=3.0
 toml>=0.9
 tree-format>=0.1.2
-jwcrypto>=0.7
+jose>=1.0.0


### PR DESCRIPTION
Add a new command which will generate JWT token with the following claims:
```json
{
  "iss": "futaba-{guild id}",
  "did": "{user id}",
  "dnn": "{user display name}",
  "jdt": "{user unix join dt}",
  "iat": "{epoch timestamp}"
}
```

The JWT is signed with a secret that is configured with the bot, using HS256 for signing.

Initially intended to be used for the programming server's MC server - as a way to authenticate new users on the MC server, linking them to users in the discord server. But, this can surely be used for other things.