### PR TITLE
Update moderation SQL model

### DIFF
--- a/futaba/sql/models/moderation.py
+++ b/futaba/sql/models/moderation.py
@@ -114,6 +114,8 @@ class ModerationModel:
             kept_roles = [
                 discord.utils.get(member.guild.roles, id=id) for id in kept_role_ids
             ]
+            # Append managed roles to kept roles as bot cannot remove them
+            kept_roles.append(discord.utils.get(member.guild.roles, managed=True))
 
             upd = (
                 self.tb_removed_other_roles.update()
@@ -129,6 +131,8 @@ class ModerationModel:
         else:
             # Add new removed_other_roles row
             kept_roles = [kept_role]
+            # Append managed roles to kept roles as bot cannot remove them
+            kept_roles.append(discord.utils.get(member.guild.roles, managed=True))
             other_role_ids = [role.id for role in member.roles if role != kept_role]
             ins = self.tb_removed_other_roles.insert().values(
                 guild_id=member.guild.id,


### PR DESCRIPTION
Update moderation SQL model to include managed roles as a kept role so the bot will not attempt to remove them and error when it fails.