### PR TITLE
Add separate commands for deletion-days ban, timed jail, unjail

### DIFF
--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["Authentication"]
 
+
 class Authentication(AbstractCog):
     __slots__ = ("journal",)
 

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -57,6 +57,5 @@ class Authentication(AbstractCog):
 
         logger.info("User '%s' (%d) generated a JWT", ctx.author.name, ctx.author.id)
 
-        response = f"Generated authentication token: ```{token}```"
-
+        response = f"Generated authentication token:\n```{token}```"
         await ctx.author.send(content=response)

--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -15,11 +15,9 @@ Cog for authentication schemes and token generation
 """
 
 import logging
-import time
 from datetime import datetime
 from jose import jwt
 
-import discord
 from discord.ext import commands
 
 from ..abc import AbstractCog
@@ -43,15 +41,15 @@ class Authentication(AbstractCog):
     async def jwt(self, ctx):
         """ Generates a Javascript Web Token for a user """
 
-        epoch = datetime.utcfromtimestamp(0)
-        
+        time_since_join = ctx.author.joined_at - datetime.utcfromtimestamp(0)
+
         token = jwt.encode(
             {
                 "iss": f"futaba-{ctx.guild.id}",
                 "did": ctx.author.id,
                 "dnn": ctx.author.display_name,
-                "jdt": int((ctx.author.joined_at - epoch).total_seconds() * 1000),
-                "iat": int(time.time()),
+                "jdt": int(time_since_join.total_seconds() * 1000),
+                "iat": int(datetime.now().timestamp()),
             },
             self.jwt_secret,
             algorithm="HS256",

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -254,7 +254,9 @@ class Moderation(AbstractCog):
         logger.info("Un-jailing user '%s' (%d)", member.name, member.id)
         await self.perform_unjail(ctx, member, 0, reason)
 
-    @commands.command(name="dunjail", aliases=["dundunce", "timeunjail", "timeundunce", "drelease"])
+    @commands.command(
+        name="dunjail", aliases=["dundunce", "timeunjail", "timeundunce", "drelease"],
+    )
     @commands.guild_only()
     @permissions.check_perm("manage_roles")
     async def dunjail(
@@ -271,7 +273,6 @@ class Moderation(AbstractCog):
         )
 
         await self.perform_unjail(ctx, member, minutes, reason)
-
 
     @commands.command(name="kick")
     @commands.guild_only()

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -173,20 +173,7 @@ class Moderation(AbstractCog):
         else:
             await self.bot.punish.unjail(ctx.guild, member, reason)
 
-    @commands.command(name="jail", aliases=["dunce"])
-    @commands.guild_only()
-    @permissions.check_perm("manage_roles")
-    async def jail(self, ctx, member: MemberConv, minutes: int, *, reason: str = None):
-        """
-        Jails the user.
-        Requires a jail role to be configured.
-        The minutes parameter must be set to a positive number.
-        """
-
-        logger.info(
-            "Jailing user '%s' (%d) for %d minutes", member.name, member.id, minutes
-        )
-
+    async def perform_jail(self, ctx, member, minutes, reason):
         roles = self.bot.sql.settings.get_special_roles(ctx.guild)
         if roles.jail is None:
             raise CommandFailed(content="No configured jail role")
@@ -206,6 +193,34 @@ class Moderation(AbstractCog):
             await self.remove_roles(
                 ctx, member, minutes, PunishAction.RELIEVE_JAIL, reason
             )
+
+    @commands.command(name="jail", aliases=["dunce"])
+    @commands.guild_only()
+    @permissions.check_perm("manage_roles")
+    async def jail(self, ctx, member: MemberConv, *, reason: str = None):
+        """
+        Jails the user.
+        Requires a jail role to be configured.
+        """
+
+        logger.info("Jailing user '%s' (%d)", member.name, member.id)
+
+        await self.perform_jail(ctx, member, 0, reason)
+
+    @commands.command(name="djail", aliases=["ddunce", "timejail", "timedunce"])
+    @commands.guild_only()
+    @permissions.check_perm("manage_roles")
+    async def djail(self, ctx, member: MemberConv, minutes: int, *, reason: str = None):
+        """
+        Jails the user for a period of time.
+        Requires a jail role to be configured.
+        """
+
+        logger.info(
+            "Jailing user '%s' (%d) for %d minutes", member.name, member.id, minutes,
+        )
+
+        await self.perform_jail(ctx, member, minutes, reason)
 
     @commands.command(name="unjail", aliases=["undunce"])
     @commands.guild_only()

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -222,22 +222,7 @@ class Moderation(AbstractCog):
 
         await self.perform_jail(ctx, member, minutes, reason)
 
-    @commands.command(name="unjail", aliases=["undunce"])
-    @commands.guild_only()
-    @permissions.check_perm("manage_roles")
-    async def unjail(
-        self, ctx, member: MemberConv, minutes: int = 0, *, reason: str = None
-    ):
-        """
-        Removes a user from the jail.
-        Requires a jail role to be configured.
-        Set 'minutes' to 0 to release immediately.
-        """
-
-        logger.info(
-            "Un-jailing user '%s' (%d) in %d minutes", member.name, member.id, minutes
-        )
-
+    async def perform_unjail(self, ctx, member, minutes, reason):
         roles = self.bot.sql.settings.get_special_roles(ctx.guild)
         if roles.jail is None:
             raise CommandFailed(content="No configured jail role")
@@ -256,6 +241,37 @@ class Moderation(AbstractCog):
             )
         else:
             await self.bot.punish.unjail(ctx.guild, member, reason)
+
+    @commands.command(name="unjail", aliases=["undunce", "release"])
+    @commands.guild_only()
+    @permissions.check_perm("manage_roles")
+    async def unjail(self, ctx, member: MemberConv, *, reason: str = None):
+        """
+        Removes a user from the jail.
+        Requires a jail role to be configured.
+        """
+
+        logger.info("Un-jailing user '%s' (%d)", member.name, member.id)
+        await self.perform_unjail(ctx, member, 0, reason)
+
+    @commands.command(name="dunjail", aliases=["dundunce", "timeunjail", "timeundunce", "drelease"])
+    @commands.guild_only()
+    @permissions.check_perm("manage_roles")
+    async def dunjail(
+        self, ctx, member: MemberConv, minutes: int = 0, *, reason: str = None,
+    ):
+        """
+        Removes a user from the jail in the given number of minutes.
+        Requires a jail role to be configured.
+        Set 'minutes' to 0 to release immediately.
+        """
+
+        logger.info(
+            "Un-jailing user '%s' (%d) in %d minutes", member.name, member.id, minutes,
+        )
+
+        await self.perform_unjail(ctx, member, minutes, reason)
+
 
     @commands.command(name="kick")
     @commands.guild_only()

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -265,15 +265,7 @@ class Moderation(AbstractCog):
                 content="I don't have permission to kick this user"
             )
 
-    @commands.command(name="ban")
-    @commands.guild_only()
-    @permissions.check_perm("ban_members")
-    async def ban(self, ctx, user: UserConv, delete_days: int, *, reason: str):
-        """
-        Bans the user from the guild with a reason
-        If guild has moderation logging enabled, it is logged
-        """
-
+    async def perform_ban(self, ctx, user, delete_days, reason):
         if delete_days < 0 or delete_days > 7:
             embed = discord.Embed(colour=discord.Colour.red())
             embed.description = (
@@ -302,6 +294,28 @@ class Moderation(AbstractCog):
 
         except discord.errors.Forbidden:
             raise ManualCheckFailure(content="I don't have permission to ban this user")
+
+    @commands.command(name="ban")
+    @commands.guild_only()
+    @permissions.check_perm("ban_members")
+    async def ban(self, ctx, user: UserConv, *, reason: str):
+        """
+        Bans the user from the guild with a reason
+        If guild has moderation logging enabled, it is logged
+        """
+
+        await self.perform_ban(ctx, user, 0, reason)
+
+    @commands.command(name="dban", aliases=["deleteban"])
+    @commands.guild_only()
+    @permissions.check_perm("ban_members")
+    async def dban(self, ctx, user: UserConv, delete_days: int, *, reason: str):
+        """
+        Bans the user from the guild with a reason, deleting the last X days of messages
+        If guild has moderation logging enabled, it is logged
+        """
+
+        await self.perform_ban(ctx, user, delete_days, reason)
 
     @commands.command(name="softban", aliases=["soft", "sban"])
     @commands.guild_only()


### PR DESCRIPTION
Needing to put `0` as arguments has led to confusion and poor UX in many cases, as that is generally our default. Here we add alternate commands if you want to specify additional information:

* `!ban` - no deletion, `!dban` - ban with deletion
* `!jail` - untimed, `!djail` - jail for duration
* `!unjail` - immediately, `!dunjail` - unjail after delay

And address some lints in jwt command.