### PR TITLE
Fix jwt command bug

### DIFF
--- a/futaba/cogs/auth/core.py
+++ b/futaba/cogs/auth/core.py
@@ -39,6 +39,7 @@ class Authentication(AbstractCog):
         pass
 
     @commands.command(name="jwt", aliases=["dauth", "mcauth"])
+    @commands.guild_only()
     async def jwt(self, ctx):
         """ Generates a Javascript Web Token for a user """
 


### PR DESCRIPTION
error report:
```python
Timestamp: 2020-04-30 04:42:33.815814
User: [REDACTED]
Command: jwt
  Signature: 
  Prefix: 
  Cog name: Authentication
Message: (705277895307821117)
  Content: "jwt"
  Arguments:
    <futaba.cogs.auth.core.Authentication object at 0x7f9d48bbdc80>
    <discord.ext.commands.context.Context object at 0x7f9d37e164f0>
  Keyword arguments:
    (none)
Channel: DM (705277770955096114)

Traceback (most recent call last):

  File "/usr/local/lib/python3.8/dist-packages/discord/ext/commands/core.py", line 83, in wrapped
    ret = await coro(*args, **kwargs)

  File "/home/futaba/repo/futaba/cogs/auth/core.py", line 45, in jwt
    time_since_join = ctx.author.joined_at - datetime.utcfromtimestamp(0)

AttributeError: 'User' object has no attribute 'joined_at'
```