### PR TITLE
Add selfjail command

### DIFF
--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -216,6 +216,32 @@ class Moderation(AbstractCog):
 
         await self.perform_jail(ctx, member, minutes, reason)
 
+    @commands.command(name="selfjail", aliases=["selfdunce", "focus"])
+    @commands.guild_only()
+    async def self_jail(self, ctx, minutes: int = 60):
+        """
+        Jails the user that uses the command
+        Mainly used to restrict access so the user can focus without distractions
+        Requires a jail role to be configured.
+        """
+
+        # Check if user has supplied a time between 1 and 720 mins
+        if minutes <= 0 or minutes > 720:
+            embed = discord.Embed(colour=discord.Colour.red())
+            embed.description = (
+                "You need to supply a length of time between 1 and 720 mins (12 hours)"
+            )
+
+            await ctx.send(embed=embed)
+
+        else:
+            member = ctx.author
+            logger.info(
+                "Jailing user '%s' (%d) for %d minutes", member.name, member.id, minutes
+            )
+
+            await self.perform_jail(ctx, member, minutes, "Self jail")
+    
     async def perform_unjail(self, ctx, member, minutes, reason):
         roles = self.bot.sql.settings.get_special_roles(ctx.guild)
         if roles.jail is None:


### PR DESCRIPTION
Added a command allow allows a user to jail themselves in order to focus on work. (See #342) 
The maximum time the user can set for this is 720 mins (12 hours), this also forces a minimum of 1 minute so the user can not indefinitely dunce themselves.
![image](https://user-images.githubusercontent.com/18365785/80962239-917b1f00-8e04-11ea-8d49-84c96f49e5e4.png)


The default is set to 60 mins.
There is no way for the user to undo this, as such they must wait the time out, however a Mod+ can undo it but if the user has set this themselves they should wait the time out.
