### PR TITLE
Don't fail on !help if a member disables DMs

### DIFF
--- a/futaba/__init__.py
+++ b/futaba/__init__.py
@@ -23,6 +23,7 @@ from . import (
     emojis,
     enums,
     exceptions,
+    help,
     journal,
     lru,
     navi,

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -381,13 +381,13 @@ class Bot(commands.AutoShardedBot):
             else:
                 # Other exception, probably not meant to happen. Send it as an embed.
                 await self.report_other_exception(
-                    ctx, error, "Unexpected error occurred!"
+                    ctx, error, "Unexpected error occurred!",
                 )
 
         else:
             logger.error("Unknown discord command error raised", exc_info=error)
             await self.report_other_exception(
-                ctx, error, "Unwrapped exception was raised from command!"
+                ctx, error, "Unwrapped exception was raised from command!",
             )
 
     async def report_other_exception(self, ctx, error, title):

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -84,7 +84,12 @@ class Bot(commands.AutoShardedBot):
             fetch_offline_members=True,
         )
 
-        self.help_command = commands.DefaultHelpCommand(width=90, dm_help=True)
+        self.help_command = commands.DefaultHelpCommand(
+            width=90,
+            sort_commands=True,
+            dm_help=True,
+            indent=4,
+        )
 
     @staticmethod
     def my_command_prefix(bot, message):

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -85,10 +85,7 @@ class Bot(commands.AutoShardedBot):
         )
 
         self.help_command = commands.DefaultHelpCommand(
-            width=90,
-            sort_commands=True,
-            dm_help=True,
-            indent=4,
+            width=90, sort_commands=True, dm_help=True, indent=4,
         )
 
     @staticmethod
@@ -315,7 +312,7 @@ class Bot(commands.AutoShardedBot):
             )
 
         elif isinstance(
-            error, (commands.errors.BadArgument, commands.errors.BadUnionArgument)
+            error, (commands.errors.BadArgument, commands.errors.BadUnionArgument),
         ):
             # Tell the user they couldn't find what they were looking for
             logger.info("User specified argument that does not compute")
@@ -329,7 +326,7 @@ class Bot(commands.AutoShardedBot):
                 ctx.send(embed=embed), Reactions.MISSING.add(ctx.message)
             )
 
-        elif isinstance(error, commands.errors.CheckFailure):
+        elif isinstance(error, (commands.errors.CheckFailure, discord.Forbidden)):
             # Tell the user they don't have the permission to tun the command
             logger.info("Permission check for command failed")
             await Reactions.DENY.add(ctx.message)

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -497,3 +497,11 @@ class Bot(commands.AutoShardedBot):
         filename = f"futaba-extended-traceback-{unix_time}.log"
         file = discord.File(fp=full_tb.bytes_io(), filename=filename)
         await self.error_channel.send(file=file)
+
+    def __reduce__(self):
+        """
+        Empty serializer method so discord.commands doesn't try to serialize
+        this object with its live database connections and cogs and such.
+        """
+
+        return (lambda: None, ())

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -52,6 +52,14 @@ from .utils import plural, user_discrim
 logger = logging.getLogger(__name__)
 
 
+def ignore_command_hooks(ctx):
+    if ctx.command.module == "discord.ext.commands.help":
+        logger.debug("Ignoring normal command hooks for %r", ctx.command)
+        return True
+
+    return False
+
+
 class Bot(commands.AutoShardedBot):
     __slots__ = (
         "config",
@@ -244,6 +252,9 @@ class Bot(commands.AutoShardedBot):
         Handles pre-command instructions, such as adding the "wait" reaction.
         """
 
+        if ignore_command_hooks(ctx):
+            return
+
         self.loop.create_task(self._add_waiting(ctx.message))
 
     async def _add_waiting(self, message):
@@ -277,6 +288,9 @@ class Bot(commands.AutoShardedBot):
 
         # Complains about "context" vs "ctx"
         # pylint: disable=arguments-differ
+
+        if ignore_command_hooks(ctx):
+            return
 
         async with self.message_lock(ctx.message):
             try:

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -40,6 +40,7 @@ from .exceptions import (
     ManualCheckFailure,
     SendHelp,
 )
+from .help import HelpCommand
 from .journal import Broadcaster, LoggingOutputListener
 from .lru import LruCache
 from .punishment import PunishmentHandler
@@ -84,9 +85,7 @@ class Bot(commands.AutoShardedBot):
             fetch_offline_members=True,
         )
 
-        self.help_command = commands.DefaultHelpCommand(
-            width=90, sort_commands=True, dm_help=True, indent=4,
-        )
+        self.help_command = HelpCommand(self)
 
     @staticmethod
     def my_command_prefix(bot, message):

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -497,11 +497,3 @@ class Bot(commands.AutoShardedBot):
         filename = f"futaba-extended-traceback-{unix_time}.log"
         file = discord.File(fp=full_tb.bytes_io(), filename=filename)
         await self.error_channel.send(file=file)
-
-    def __reduce__(self):
-        """
-        Empty serializer method so discord.commands doesn't try to serialize
-        this object with its live database connections and cogs and such.
-        """
-
-        return (lambda: None, ())

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -84,7 +84,7 @@ class Bot(commands.AutoShardedBot):
             fetch_offline_members=True,
         )
 
-        self.help_command = commands.MinimalHelpCommand(width=90, dm_help=True)
+        self.help_command = commands.DefaultHelpCommand(width=90, dm_help=True)
 
     @staticmethod
     def my_command_prefix(bot, message):

--- a/futaba/client.py
+++ b/futaba/client.py
@@ -85,7 +85,7 @@ class Bot(commands.AutoShardedBot):
             fetch_offline_members=True,
         )
 
-        self.help_command = HelpCommand(self)
+        self.help_command = HelpCommand()
 
     @staticmethod
     def my_command_prefix(bot, message):

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -241,7 +241,7 @@ class Moderation(AbstractCog):
             )
 
             await self.perform_jail(ctx, member, minutes, "Self jail")
-    
+
     async def perform_unjail(self, ctx, member, minutes, reason):
         roles = self.bot.sql.settings.get_special_roles(ctx.guild)
         if roles.jail is None:

--- a/futaba/help.py
+++ b/futaba/help.py
@@ -14,7 +14,6 @@
 Implements modifications to the discord.py help provider class.
 """
 
-import asyncio
 import logging
 
 import discord

--- a/futaba/help.py
+++ b/futaba/help.py
@@ -1,0 +1,67 @@
+#
+# help.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2019 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+"""
+Implements modifications to the discord.py help provider class.
+"""
+
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from .utils import user_discrim
+from .enums import Reactions
+
+logger = logging.getLogger(__name__)
+
+
+class HelpCommand(commands.DefaultHelpCommand):
+    def __init__(self, client):
+        super().__init__(
+            width=90, sort_commands=True, dm_help=True, indent=4,
+        )
+
+        self.client = client
+
+    async def on_help_command_error(self, ctx, error):
+        async with self.client.message_lock(ctx.message):
+            try:
+                await self.handle_error(ctx, error)
+            except discord.NotFound:
+                pass
+
+    async def handle_error(self, ctx, error):
+        if isinstance(error, discord.Forbidden):
+            logger.debug(
+                "Lacks permissions to send help to %s (%d)",
+                user_discrim(ctx.author),
+                ctx.author.id,
+            )
+
+            embed = discord.Embed(colour=discord.Colour.red())
+            embed.title = "Cannot send help command"
+            embed.description = (
+                "You do not allow DMs from this server. "
+                "Please enable them so help information can be sent."
+            )
+
+            await asyncio.gather(
+                ctx.send(embed=embed), Reactions.DENY.add(ctx.message),
+            )
+
+        else:
+            logger.error("Unknown discord command error raised", exc_info=error)
+            await self.client.report_other_exception(
+                ctx, error, "Unwrapped exception was raised from command!",
+            )

--- a/futaba/help.py
+++ b/futaba/help.py
@@ -40,6 +40,7 @@ class HelpCommand(commands.DefaultHelpCommand):
 
     async def handle_error(self, ctx, error):
         reported = False
+        await Reactions.DENY.add(ctx.message)
 
         if isinstance(error, commands.errors.CommandInvokeError):
             error = error.__cause__
@@ -59,14 +60,11 @@ class HelpCommand(commands.DefaultHelpCommand):
                 )
 
                 reported = True
-                await asyncio.gather(
-                    ctx.send(embed=embed), Reactions.DENY.add(ctx.message),
-                )
-
+                await ctx.send(embed=embed)
 
         # Default error handling
         if not reported:
             logger.error("Unexpected error raised during help command", exc_info=error)
-            await self.bot.report_other_exception(
+            await ctx.bot.report_other_exception(
                 ctx, error, "Unexpected error occurred during help command!",
             )

--- a/futaba/help.py
+++ b/futaba/help.py
@@ -27,15 +27,13 @@ logger = logging.getLogger(__name__)
 
 
 class HelpCommand(commands.DefaultHelpCommand):
-    def __init__(self, client):
+    def __init__(self):
         super().__init__(
             width=90, sort_commands=True, dm_help=True, indent=4,
         )
 
-        self.client = client
-
     async def on_help_command_error(self, ctx, error):
-        async with self.client.message_lock(ctx.message):
+        async with ctx.bot.message_lock(ctx.message):
             try:
                 await self.handle_error(ctx, error)
             except discord.NotFound:
@@ -62,6 +60,6 @@ class HelpCommand(commands.DefaultHelpCommand):
 
         else:
             logger.error("Unknown discord command error raised", exc_info=error)
-            await self.client.report_other_exception(
+            await ctx.bot.report_other_exception(
                 ctx, error, "Unwrapped exception was raised from command!",
             )


### PR DESCRIPTION
Right now the default error handler kicks in if a server member requests `!help` but they don't allow DMs. This modifies the standard help provider to catch this and provide an error message in channel to help them.

This also changes our help provider to be the default rather than minimalist one.