### PR TITLE
Address minor self-gaol issues

### DIFF
--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -230,21 +230,18 @@ class Moderation(AbstractCog):
 
         # Check if user has supplied a time between 1 and 720 mins
         if minutes <= 0 or minutes > 720:
-            embed = discord.Embed(colour=discord.Colour.red())
-            embed.description = (
-                "You need to supply a length of time between 1 and 720 mins (12 hours)"
+            embed = discord.Embed(
+                colour=discord.Colour.red(),
+                description="You need to supply a length of time between 1 and 720 mins (12 hours)",
             )
+            raise CommandFailed(embed=embed)
 
-            await ctx.send(embed=embed)
-
-        else:
-            member = ctx.author
-            logger.info(
-                "Jailing user '%s' (%d) for %d minutes", member.name, member.id, minutes
-            )
-
-            await self.perform_jail(ctx, member, minutes, "Self jail")
-            await self.perform_mute(ctx, member, minutes, "Self jail")
+        member = ctx.author
+        logger.info(
+            "Jailing user '%s' (%d) for %d minutes", member.name, member.id, minutes
+        )
+        await self.perform_jail(ctx, member, minutes, "Self jail")
+        await self.perform_mute(ctx, member, minutes, "Self jail")
 
     async def perform_unjail(self, ctx, member, minutes, reason):
         roles = self.bot.sql.settings.get_special_roles(ctx.guild)

--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -228,11 +228,11 @@ class Moderation(AbstractCog):
         Requires a jail role to be configured.
         """
 
-        # Check if user has supplied a time between 1 and 720 mins
-        if minutes <= 0 or minutes > 720:
+        # Check if user has supplied a time between 30 and 720 mins
+        if minutes < 30 or minutes > 720:
             embed = discord.Embed(
                 colour=discord.Colour.red(),
-                description="You need to supply a length of time between 1 and 720 mins (12 hours)",
+                description="You need to supply a length of time between 30 and 720 mins (12 hours)",
             )
             raise CommandFailed(embed=embed)
 


### PR DESCRIPTION
This PR does the following:

- Increases the minimum amount of time one can self-gaol themselves for
- Makes it so that when the command fails, a red cross is displayed instead of a green tick

![Screenshot from 2020-05-28 20-42-19](https://user-images.githubusercontent.com/65943476/83132174-88fac900-a0d0-11ea-98df-d62c0ed07b4c.png)
