### PR TITLE
Allow members to remove their own messages

### DIFF
--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -199,14 +199,9 @@ class Cleanup(AbstractCog):
         )
         self.dump.send("id", ctx.guild, content, icon="delete", messages=obj, file=file)
 
-    @commands.command(name="cleanupuser", aliases=["cleanuser"])
-    @commands.guild_only()
-    @permissions.check_perm("manage_messages")
-    async def cleanup_user(
+    async def perform_cleanup_user(
         self, ctx, user: discord.User, count: int, channel: discord.TextChannel = None
     ):
-        """ Deletes the last <count> messages created by the given user. """
-
         await self.check_count(ctx, count)
 
         if channel is None:
@@ -246,6 +241,25 @@ class Cleanup(AbstractCog):
         self.dump.send(
             "user", ctx.guild, content, icon="delete", messages=obj, file=file
         )
+
+    @commands.command(name="cleanupself", aliases=["cleanself"])
+    @commands.guild_only()
+    async def cleanup_self(self, ctx, count: int, channel: discord.TextChannel = None):
+        """
+        Deletes the last <count> messages created by the causer.
+        """
+        await self.perform_cleanup_user(ctx, ctx.author, count, channel)
+
+    @commands.command(name="cleanupuser", aliases=["cleanuser"])
+    @commands.guild_only()
+    @permissions.check_perm("manage_messages")
+    async def cleanup_user(
+        self, ctx, user: discord.User, count: int, channel: discord.TextChannel = None
+    ):
+        """
+        Deletes the last <count> messages created by the given user.
+        """
+        await self.perform_cleanup_user(ctx, user, count, channel)
 
     @commands.command(name="cleanuptext", aliases=["cleantext"])
     @commands.guild_only()


### PR DESCRIPTION
This PR is a first attempt at allowing members to delete their own messages (see issue https://github.com/strinking/futaba/issues/343). Gordon has previously raised concern over some members potentially abusing this command, so I would like to hear some feedback in regards to this functionality.

TODO: Add a cool-down per member.

![Screenshot from 2020-05-28 22-55-03](https://user-images.githubusercontent.com/65943476/83144130-7b4e3f00-a0e2-11ea-8616-c806d6a81c53.png)
