### PR TITLE
Distinguish between months and minutes

### DIFF
--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -98,7 +98,9 @@ class Moderation(AbstractCog):
             nick=nick, reason=f"{mod} {'un' if nick is None else ''}set nickname"
         )
 
-    async def perform_mute(self, ctx, member: MemberConv, minutes: int, reason: str = None):
+    async def perform_mute(
+        self, ctx, member: MemberConv, minutes: int, reason: str = None,
+    ):
         logger.info(
             "Muting user '%s' (%d) for %d minutes", member.name, member.id, minutes
         )

--- a/futaba/utils.py
+++ b/futaba/utils.py
@@ -108,9 +108,9 @@ def fancy_timedelta(delta):
     seconds += delta.microseconds / 1e6
 
     if years:
-        result.write(f"{years}y")
+        result.write(f"{years}Y")
     if months:
-        result.write(f"{months}m")
+        result.write(f"{months}M")
     if weeks:
         result.write(f"{weeks}w")
     if days:

--- a/futaba/utils.py
+++ b/futaba/utils.py
@@ -108,9 +108,9 @@ def fancy_timedelta(delta):
     seconds += delta.microseconds / 1e6
 
     if years:
-        result.write(f"{years}Y")
+        result.write(f"{years}y")
     if months:
-        result.write(f"{months}M")
+        result.write(f"{months}mo")
     if weeks:
         result.write(f"{weeks}w")
     if days:


### PR DESCRIPTION
Use "mo" for months and "m" for minutes.