### PR TITLE
Allow deleting all of a user's messages across all channels

### DIFF
--- a/futaba/client.py
+++ b/futaba/client.py
@@ -53,6 +53,9 @@ logger = logging.getLogger(__name__)
 
 
 def ignore_command_hooks(ctx):
+    if ctx.command is None:
+        return False
+
     if ctx.command.module == "discord.ext.commands.help":
         logger.debug("Ignoring normal command hooks for %r", ctx.command)
         return True

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -322,7 +322,7 @@ class Cleanup(AbstractCog):
     def add_deletion_code(self, guild, user):
         """ Adds a deletion code to the temporary mapping for use. """
 
-        code = ''.join(random.choice(DELETION_CHARACTERS) for _ in range(16))
+        code = "".join(random.choice(DELETION_CHARACTERS) for _ in range(16))
 
         # Escape hatch in the unlikely case where a duplicate code is generated
         if code in self.delete_codes:
@@ -374,7 +374,9 @@ class Cleanup(AbstractCog):
         except KeyError:
             embed = discord.Embed(colour=discord.Colour.red())
             embed.title = "Complete user message purge"
-            embed.description = "Invalid code provided, no deletion queue exists with that value."
+            embed.description = (
+                "Invalid code provided, no deletion queue exists with that value."
+            )
             raise CommandFailed(embed=embed)
 
         # Notify that deletion has begun
@@ -453,7 +455,9 @@ class Cleanup(AbstractCog):
         except KeyError:
             embed = discord.Embed(colour=discord.Colour.red())
             embed.title = "Complete user message purge"
-            embed.description = "Invalid code provided, no deletion queue exists with that value."
+            embed.description = (
+                "Invalid code provided, no deletion queue exists with that value."
+            )
             raise CommandFailed(embed=embed)
 
         # Actually perform the deletion

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -21,6 +21,7 @@ import discord
 from discord.ext import commands
 
 from futaba import permissions
+from futaba.converters import UserConv
 from futaba.dict_convert import message_dict
 from futaba.exceptions import CommandFailed
 from futaba.str_builder import StringBuilder
@@ -296,3 +297,19 @@ class Cleanup(AbstractCog):
         self.dump.send(
             "text", ctx.guild, content, icon="delete", messages=obj, file=file
         )
+
+    @commands.command(name="cleanupalltime", aliases=["cleanupforever"])
+    @commands.guild_only()
+    @permissions.check_perm("manage_messages")
+    async def cleanup_user_entirely(self, ctx, user: UserConv):
+        """ Setup command to delete all of a user's messages in all channels forever. """
+
+        description = (
+            f"You are about to delete **all** the messages ever sent by user {user.mention}.\n"
+            "This is **irreversible**, will affect **all** channels and has **no limit** "
+            "to the number of messages deleted.\n\n"
+            "Are you __sure__ you would like to do this?\n"
+            f"If so, run \"{ctx.prefix}cleanuplltimeconfirm -force {user.mention}\""
+        )
+        embed = discord.Embed(colour=discord.Colour.dark_teal(), description=description)
+        await ctx.send(embed=embed)

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -345,7 +345,7 @@ class Cleanup(AbstractCog):
             "This is **irreversible**, will affect **all** channels and has **no limit** "
             "to the number of messages deleted.\n\n"
             "Are you **sure** you would like to do this?\n\n"
-            f"If so, run `{ctx.prefix}cleanuplltimeconfirm -force {code}`.\n"
+            f"If so, run `{ctx.prefix}cleanuplltimeconfirm -force {code}`\n"
             f"This code will expire in {EXPIRES_MINUTES} minutes, or you can run "
             f"`{ctx.prefix}cleanupallcancel {code}`"
         )

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -344,9 +344,9 @@ class Cleanup(AbstractCog):
             f"You are about to delete **all** the messages ever sent by user {user.mention}.\n"
             "This is **irreversible**, will affect **all** channels and has **no limit** "
             "to the number of messages deleted.\n\n"
-            "Are you __sure__ you would like to do this?\n"
-            f"If so, run `{ctx.prefix}cleanuplltimeconfirm -force {code}` "
-            f"(this code will expire in {EXPIRES_MINUTES} minutes, or you can cancel early with "
+            "Are you **sure** you would like to do this?\n\n"
+            f"If so, run `{ctx.prefix}cleanuplltimeconfirm -force {code}`.\n"
+            f"This code will expire in {EXPIRES_MINUTES} minutes, or you can run "
             f"`{ctx.prefix}cleanupallcancel {code}`"
         )
         await ctx.send(embed=embed)

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -345,7 +345,7 @@ class Cleanup(AbstractCog):
             "This is **irreversible**, will affect **all** channels and has **no limit** "
             "to the number of messages deleted.\n\n"
             "Are you **sure** you would like to do this?\n\n"
-            f"If so, run `{ctx.prefix}cleanuplltimeconfirm -force {code}`\n"
+            f"If so, run `{ctx.prefix}cleanupalltimeconfirm -force {code}`\n"
             f"This code will expire in {EXPIRES_MINUTES} minutes, or you can run "
             f"`{ctx.prefix}cleanupallcancel {code}`"
         )

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -393,12 +393,19 @@ class Cleanup(AbstractCog):
         def check(message):
             if flag.value:
                 # If this is set, then the deletion has been cancelled.
-                return False
+                raise KeyboardInterrupt
 
             return message.author == user
 
         # Run deletions
-        deleted = await self.purge_all_messages(guild, user, check)
+        try:
+            deleted = await self.purge_all_messages(guild, user, check)
+        except KeyboardInterrupt:
+            elapsed = datetime.now() - start
+            embed = discord.Embed(colour=discord.Colour.red())
+            embed.title = "Complete user message purge cancelled"
+            embed.description = f"Deletion was cancelled. Spent {fancy_timedelta(elapsed)} in deletion."
+            raise CommandFailed(embed=embed)
 
         # Notify that deletions are finished
         elapsed = datetime.now() - start

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -60,6 +60,18 @@ class _Counter:
         self.value += 1
 
 
+class _Flag:
+    """ Mutable boolean value. See also _Counter. """
+
+    __slots__ = ("value",)
+
+    def __init__(self):
+        self.value = False
+
+    def set(self):
+        self.value = True
+
+
 class Cleanup(AbstractCog):
     __slots__ = ("journal", "dump", "delete_codes")
 
@@ -315,7 +327,7 @@ class Cleanup(AbstractCog):
         if code in self.delete_codes:
             return self.add_deletion_code(guild, user)
 
-        self.delete_codes[code] = guild, user
+        self.delete_codes[code] = guild, user, _Flag()
         return code
 
     @commands.command(name="cleanupalltime", aliases=["cleanupforever"])
@@ -353,7 +365,7 @@ class Cleanup(AbstractCog):
 
         # Get deletion information from code
         try:
-            guild, user = self.delete_codes[code]
+            guild, user, flag = self.delete_codes[code]
 
             # Check if the guilds match
             if guild != ctx.guild:
@@ -373,7 +385,15 @@ class Cleanup(AbstractCog):
         )
         await ctx.send(embed=embed)
 
-        # Start deletions
+        # Deletion condition function
+        def check(message):
+            if flag.value:
+                # If this is set, then the deletion has been cancelled.
+                return False
+
+            return ...
+
+        # Run deletions
         # ...
         messages = []
 
@@ -390,7 +410,7 @@ class Cleanup(AbstractCog):
         """ Cancels a deletion code. """
 
         try:
-            guild, user = self.delete_codes[code]
+            guild, user, flag = self.delete_codes[code]
 
             # Check if the guilds match
             if guild != ctx.guild:
@@ -402,6 +422,7 @@ class Cleanup(AbstractCog):
             raise CommandFailed(embed=embed)
 
         # Actually perform the deletion
+        flag.set()
         del self.delete_codes[code]
 
         # Send result

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -324,12 +324,15 @@ class Cleanup(AbstractCog):
     async def cleanup_user_entirely(self, ctx, user: UserConv):
         """ Setup command to delete all of a user's messages in all channels forever. """
 
-        description = (
+        code = self.add_deletion_code(self, user)
+        embed = discord.Embed(colour=discord.Colour.dark_teal())
+        embed.description = (
             f"You are about to delete **all** the messages ever sent by user {user.mention}.\n"
             "This is **irreversible**, will affect **all** channels and has **no limit** "
             "to the number of messages deleted.\n\n"
             "Are you __sure__ you would like to do this?\n"
-            f"If so, run \"{ctx.prefix}cleanuplltimeconfirm -force {user.mention}\""
+            f"If so, run `{ctx.prefix}cleanuplltimeconfirm -force {code}` "
+            f"(this code will expire in {EXPIRES_MINUTES} minutes)"
         )
         embed = discord.Embed(colour=discord.Colour.dark_teal(), description=description)
         await ctx.send(embed=embed)

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -406,6 +406,11 @@ class Cleanup(AbstractCog):
         await ctx.send(embed=embed)
 
     async def purge_all_messages(self, guild, user, check):
+        """
+        Implementation function for actually removing all messages by a user.
+        Don't run this directly!
+        """
+
         # Task for deleting all messages within a channel
         async def purge_channel(channel):
             logger.debug(

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -322,7 +322,7 @@ class Cleanup(AbstractCog):
     def add_deletion_code(self, guild, user):
         """ Adds a deletion code to the temporary mapping for use. """
 
-        code = "".join(random.choice(DELETION_CHARACTERS) for _ in range(16))
+        code = "".join(random.choice(DELETION_CHARACTERS) for _ in range(8))
 
         # Escape hatch in the unlikely case where a duplicate code is generated
         if code in self.delete_codes:

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -393,14 +393,14 @@ class Cleanup(AbstractCog):
         def check(message):
             if flag.value:
                 # If this is set, then the deletion has been cancelled.
-                raise KeyboardInterrupt
+                raise ValueError
 
             return message.author == user
 
         # Run deletions
         try:
             deleted = await self.purge_all_messages(guild, user, check)
-        except KeyboardInterrupt:
+        except ValueError:
             elapsed = datetime.now() - start
             embed = discord.Embed(colour=discord.Colour.red())
             embed.title = "Complete user message purge cancelled"
@@ -467,6 +467,7 @@ class Cleanup(AbstractCog):
         """ Cancels a deletion code. """
 
         try:
+            print(self.delete_codes, code)
             guild, user, flag = self.delete_codes[code]
 
             # Check if the guilds match

--- a/futaba/cogs/moderation/cleanup.py
+++ b/futaba/cogs/moderation/cleanup.py
@@ -333,7 +333,7 @@ class Cleanup(AbstractCog):
 
     @commands.command(name="cleanupalltime", aliases=["cleanupforever"])
     @commands.guild_only()
-    @permissions.check_perm("manage_messages")
+    @permissions.check_admin()
     async def cleanup_user_entirely(self, ctx, user: UserConv):
         """ Setup command to delete all of a user's messages in all channels forever. """
 
@@ -353,7 +353,7 @@ class Cleanup(AbstractCog):
 
     @commands.command(name="cleanupalltimeconfirm")
     @commands.guild_only()
-    @permissions.check_perm("manage_messages")
+    @permissions.check_admin()
     async def cleanup_user_entirely_run(self, ctx, confirm: str, code: str):
         """ Use !cleanupalltime instead. """
 
@@ -442,7 +442,7 @@ class Cleanup(AbstractCog):
 
     @commands.command(name="cleanupallcancel", aliases=["cleanupforevercancel"])
     @commands.guild_only()
-    @permissions.check_perm("manage_messages")
+    @permissions.check_admin()
     async def cleanup_user_cancel(self, ctx, code: str):
         """ Cancels a deletion code. """
 

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -343,6 +343,7 @@ class Tracker(AbstractCog):
         self.journal.send(
             "message/delete/bulk",
             guild,
+            content,
             icon="delete",
             messages=messages,
         )

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -44,6 +44,7 @@ LISTENERS = (
     "on_message",
     "on_message_edit",
     "on_message_delete",
+    "on_bulk_message_delete",
     "on_reaction_add",
     "on_reaction_remove",
     "on_reaction_clear",
@@ -322,6 +323,31 @@ class Tracker(AbstractCog):
             message=message,
             embed=self.build_embed(message),
         )
+
+    async def on_bulk_message_delete(self, messages):
+        if not messages:
+            return
+
+        guild = messages[0].guild
+        if guild is None:
+            return
+
+        logger.debug(
+            "Bulk delete of %d messages from guild '%s' (%d) performed"
+            len(messages),
+            guild.name,
+            guild.id,
+        )
+
+        content = f"{len(messages)} messages were bulk deleted"
+        self.journal.send(
+            "message/delete/bulk",
+            guild,
+            icon="delete",
+            messages=messages,
+        )
+
+        # Don't send full contents, with bulk deletes there could be a huge amount of messages
 
     async def on_reaction_add(self, reaction, user):
         if (reaction, user) in self.reactions:

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -333,7 +333,7 @@ class Tracker(AbstractCog):
             return
 
         logger.debug(
-            "Bulk delete of %d messages from guild '%s' (%d) performed"
+            "Bulk delete of %d messages from guild '%s' (%d) performed",
             len(messages),
             guild.name,
             guild.id,

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -343,11 +343,7 @@ class Tracker(AbstractCog):
 
         content = f"{len(messages)} messages were bulk deleted"
         self.journal.send(
-            "message/delete/bulk",
-            guild,
-            content,
-            icon="delete",
-            messages=messages,
+            "message/delete/bulk", guild, content, icon="delete", messages=messages,
         )
 
         # Don't send full contents, with bulk deletes there could be a huge amount of messages

--- a/futaba/cogs/tracker/core.py
+++ b/futaba/cogs/tracker/core.py
@@ -332,9 +332,11 @@ class Tracker(AbstractCog):
         if guild is None:
             return
 
+        channels = {message.channel for message in messages}
         logger.debug(
-            "Bulk delete of %d messages from guild '%s' (%d) performed",
+            "Bulk delete of %d messages across %d channels from guild '%s' (%d) performed",
             len(messages),
+            len(channels),
             guild.name,
             guild.id,
         )

--- a/futaba/expiry_dict.py
+++ b/futaba/expiry_dict.py
@@ -16,6 +16,7 @@ Collection that has keys which expire.
 
 from datetime import datetime
 
+
 class ExpiryDict:
     __slots__ = ("items", "expire_time")
 

--- a/futaba/expiry_dict.py
+++ b/futaba/expiry_dict.py
@@ -1,0 +1,51 @@
+#
+# expiry_dict.py
+#
+# futaba - A Discord Mod bot for the Programming server
+# Copyright (c) 2017-2020 Jake Richardson, Ammon Smith, jackylam5
+#
+# futaba is available free of charge under the terms of the MIT
+# License. You are free to redistribute and/or modify it under those
+# terms. It is distributed in the hopes that it will be useful, but
+# WITHOUT ANY WARRANTY. See the LICENSE file for more details.
+#
+
+"""
+Collection that has keys which expire.
+"""
+
+from datetime import datetime
+
+class ExpiryDict:
+    __slots__ = ("items", "expire_time")
+
+    def __init__(self, expire_time):
+        self.items = {}
+        self.expire_time = expire_time
+
+    def prune(self):
+        now = datetime.now()
+
+        for key in tuple(self.items.keys()):
+            expires_at, _ = self.items[key]
+
+            if expires_at > now:
+                del self.items[key]
+
+    def __getitem__(self, key):
+        self.prune()
+        return self.items[key]
+
+    def __setitem__(self, key, value):
+        self.prune()
+        expires_at = datetime.now() + self.expire_time
+        self.items[key] = expires_at, value
+
+    def __delitem__(self, key):
+        del self.items[key]
+
+    def __contains__(self, key):
+        return key in self.items
+
+    def keys(self):
+        return self.items.keys()

--- a/futaba/expiry_dict.py
+++ b/futaba/expiry_dict.py
@@ -30,12 +30,13 @@ class ExpiryDict:
         for key in tuple(self.items.keys()):
             expires_at, _ = self.items[key]
 
-            if expires_at > now:
+            if now > expires_at:
                 del self.items[key]
 
     def __getitem__(self, key):
         self.prune()
-        return self.items[key]
+        _, value = self.items[key]
+        return value
 
     def __setitem__(self, key, value):
         self.prune()


### PR DESCRIPTION
As requested by a member, this allows removing all messages a user has sent. Because there is a risk of over-deletion, our other cleanup commands have a limit and are isolated to one channel. Here we have a confirmation process to avoid accidentally removing large numbers of messages unintentionally, and the command itself can only be run by administrators.

**Starting the process:**
![image](https://user-images.githubusercontent.com/8848022/88619425-82091c00-d069-11ea-94a4-a3f2ac2d4105.png)

**Confirming and beginning deletion:**
![image](https://user-images.githubusercontent.com/8848022/88619479-9d742700-d069-11ea-913d-e452e8a9c4a5.png)

**Failing to confirm the deletion:**
![image](https://user-images.githubusercontent.com/8848022/88620838-f98c7a80-d06c-11ea-9ac3-25b0e4fa379d.png)

**Cancellation before execution:**
![image](https://user-images.githubusercontent.com/8848022/88619528-b8df3200-d069-11ea-81a6-77f506b51a16.png)

**Cancellation during execution:**
![image](https://user-images.githubusercontent.com/8848022/88619379-6dc51f00-d069-11ea-83a4-63038e1c58a0.png)

**Result on completion:**
![image](https://user-images.githubusercontent.com/8848022/88620478-23916d00-d06c-11ea-9f6b-a4afa8ada21d.png)
