### PR TITLE
Fix futaba sending checkmark for unknown filter subcommands

### DIFF
--- a/futaba/cogs/filter/core.py
+++ b/futaba/cogs/filter/core.py
@@ -233,7 +233,7 @@ class Filtering(AbstractCog):
         Maintaining the list of special user immunities to the filter.
         """
 
-        if ctx.subcommand_passed in ("immune", "imm", "ignore", "ign"):
+        if ctx.invoked_subcommand is None:
             raise SendHelp()
 
     @filter_immunity.command(name="add", aliases=["append", "extend", "new"])
@@ -375,7 +375,7 @@ class Filtering(AbstractCog):
         Allows managing the server-wide filter.
         """
 
-        if ctx.subcommand_passed in ("server", "srv", "s", "guild", "g"):
+        if ctx.invoked_subcommand is None:
             raise SendHelp()
 
     @filter_guild.command(name="show", aliases=["display", "list"])
@@ -469,7 +469,7 @@ class Filtering(AbstractCog):
         Allows managing the local channel filter.
         """
 
-        if ctx.subcommand_passed in ("chan", "ch", "c"):
+        if ctx.invoked_subcommand is None:
             raise SendHelp()
 
     @filter_channel.command(name="show", aliases=["display", "list"])


### PR DESCRIPTION
Futaba currently reacts with a checkmark whenever an incorrect filter subcommand is passed, ie `!filter g no u`. ctx.invoked_subcommand is only valid when a subcommand is invoked: [doc](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html?highlight=invoked_subcommand#discord.ext.commands.Context.invoked_subcommand). This takes care of both cases where no subcommand is passed at all and when a wrong one is passed. 