### PR TITLE
Support regular expressions in the filter

### DIFF
--- a/futaba/cogs/filter/filter.py
+++ b/futaba/cogs/filter/filter.py
@@ -127,8 +127,10 @@ class Filter:
 
                     # Overwrite this lexeme
                     regex_ast[index] = in_lexeme_tuple
-            elif isinstance(value, Iterable):
-                # More possible lexemes, recurse and overwrite...
+                else:
+                    # More possible lexemes, recurse and overwrite...
+                    regex_ast[index] = tuple(Filter.convert_raw_regex_ast(list(value)))
+            elif isinstance(value, sre_parse.SubPattern):
                 regex_ast[index] = Filter.convert_raw_regex_ast(value)
 
         return regex_ast

--- a/futaba/cogs/filter/filter.py
+++ b/futaba/cogs/filter/filter.py
@@ -119,20 +119,14 @@ class Filter:
                     group = groups[0]  # one char, so only one group
                     confusable_literals = [lexeme_tuple]
                     for homoglyph in group["homoglyphs"]:
-                        if len(homoglyph["c"]) > 1:
-                            confusable_literals += [
-                                (sre_parse.LITERAL, ord(char))
-                                for char in homoglyph["c"]
-                            ]
-                        else:
-                            confusable_literals.append(
-                                (sre_parse.LITERAL, ord(homoglyph["c"]))
-                            )
+                        confusable_literals += [
+                            (sre_parse.LITERAL, ord(char)) for char in homoglyph["c"]
+                        ]
                     in_lexeme_tuple = (sre_parse.IN, confusable_literals)
 
                     # Overwrite this lexeme
                     regex_ast[index] = in_lexeme_tuple
-            elif isinstance(value, Iterable):  # list or set
+            elif isinstance(value, Iterable):
                 # More possible lexemes, recurse and overwrite...
                 regex_ast[index] = Filter.convert_raw_regex_ast(value)
 

--- a/futaba/cogs/filter/filter.py
+++ b/futaba/cogs/filter/filter.py
@@ -12,6 +12,7 @@
 
 import logging
 import re
+# pylint: disable=no-member
 import sre_parse
 import sre_compile
 

--- a/futaba/cogs/filter/filter.py
+++ b/futaba/cogs/filter/filter.py
@@ -10,9 +10,9 @@
 # WITHOUT ANY WARRANTY. See the LICENSE file for more details.
 #
 
+# pylint: disable=no-member
 import logging
 import re
-# pylint: disable=no-member
 import sre_parse
 import sre_compile
 


### PR DESCRIPTION
Filter strings starting with `regex:` are built into generic regular expressions when created.

`convert_raw_regex_ast` supports `confusable_homoglyphs`. It automatically converts character literals into sets of confusable homoglyphs. For example, the filter string `regex:^asdf(.*)$` is automatically built as this:
```
^[a⍺ａ𝐚𝑎𝒂𝒶𝓪𝔞𝕒𝖆𝖺𝗮𝘢𝙖𝚊ɑα𝛂𝛼𝜶𝝰𝞪а][sｓ𝐬𝑠𝒔𝓈𝓼𝔰𝕤𝖘𝗌𝘀𝘴𝙨𝚜ꜱƽѕꮪ𑣁𐑈][dⅾⅆ𝐝𝑑𝒅𝒹𝓭𝔡𝕕𝖉𝖽𝗱𝘥𝙙𝚍ԁᏧᑯꓒ][f𝐟𝑓𝒇𝒻𝓯𝔣𝕗𝖋𝖿𝗳𝘧𝙛𝚏ꬵꞙſẝք](.*)$
```

Filter strings starting with `raw-regex:` will not undergo any such conversion.

This PR resolves #145 and #193.

Note: Because of the operations on the regex AST, a pattern string for confusable-fixed regular expressions will print as `Generated pattern: '<synthetic regular expression>'` in the log due to limitations with Python's regex syntax modules.