### PR TITLE
Add check to make sure a user can not jail/mute a user with the same highest role as them

### DIFF
--- a/futaba/cogs/moderation/core.py
+++ b/futaba/cogs/moderation/core.py
@@ -121,6 +121,11 @@ class Moderation(AbstractCog):
         if roles.mute_role in member.roles:
             raise CommandFailed(content="User is already muted")
 
+        # Check that users top role is not the same as the requesters top role.
+        if member != ctx.author:
+            if member.top_role == ctx.author.top_role:
+                raise CommandFailed(content="You can not mute a user with the same role as you")
+
         minutes = max(minutes, 0)
         reason = self.build_reason(ctx, "Muted", minutes, reason, past=True)
 
@@ -170,6 +175,11 @@ class Moderation(AbstractCog):
         if roles.mute_role not in member.roles:
             raise CommandFailed(content="User is not muted")
 
+        # Check that users top role is not the same as the requesters top role.
+        if member != ctx.author:
+            if member.top_role == ctx.author.top_role:
+                raise CommandFailed(content="You can not unmute a user with the same role as you")
+
         minutes = max(minutes, 0)
         reason = self.build_reason(ctx, "Unmuted", minutes, reason, past=True)
 
@@ -190,6 +200,11 @@ class Moderation(AbstractCog):
 
         if roles.jail_role in member.roles:
             raise CommandFailed(content="User is already jailed")
+
+        # Check that users top role is not the same as the requesters top role.
+        if member != ctx.author:
+            if member.top_role == ctx.author.top_role:
+                raise CommandFailed(content="You can not jail a user with the same role as you")
 
         minutes = max(minutes, 0)
         reason = self.build_reason(ctx, "Jailed", minutes, reason)
@@ -264,6 +279,10 @@ class Moderation(AbstractCog):
 
         if roles.jail_role not in member.roles:
             raise CommandFailed(content="User is not jailed")
+
+        if member != ctx.author:
+            if member.top_role == ctx.author.top_role:
+                raise CommandFailed(content="You can not unjail a user with the same role as you")
 
         minutes = max(minutes, 0)
         reason = self.build_reason(ctx, "Released", minutes, reason, past=True)


### PR DESCRIPTION
Added a check to stop a user jailing / muting a user if the both have the same top role as each other