### PR TITLE
Added handler for ExpectedClosingQuoteError

### DIFF
--- a/futaba/client.py
+++ b/futaba/client.py
@@ -401,6 +401,17 @@ class Bot(commands.AutoShardedBot):
                     ctx, error, "Unexpected error occurred!",
                 )
 
+        elif isinstance(error, commands.errors.ExpectedClosingQuoteError):
+            logger.info("User is missing closing quote for command")
+
+            # Create the embed to tell the user that they are missing a closing quote
+            embed = discord.Embed(colour=discord.Colour.red())
+            embed.title = "Closing quote missing"
+
+            await asyncio.gather(
+                ctx.send(embed=embed), Reactions.MISSING.add(ctx.message)
+            )
+
         else:
             logger.error("Unknown discord command error raised", exc_info=error)
             await self.report_other_exception(


### PR DESCRIPTION
This PR adds a handler for the missing quotes error... this one: 
<img width="408" alt="image" src="https://user-images.githubusercontent.com/10201802/91780324-80e28600-ebf7-11ea-955b-78f7cb0cbddc.png">
Implemented meaningful reply looks like this : 
<img width="218" alt="image" src="https://user-images.githubusercontent.com/10201802/91780361-a1124500-ebf7-11ea-9eea-a125629d0504.png">

