### PR TITLE
Change the focus command to use a separate role

### DIFF
--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -238,6 +238,7 @@ class Settings(AbstractCog):
                 f'{ICONS["guest"]} Guest: {mention(roles.guest)}',
                 f'{ICONS["mute"]} Mute: {mention(roles.mute)}',
                 f'{ICONS["jail"]} Jail: {mention(roles.jail)}',
+                f'{ICONS["focus"]} Focus: {mention(roles.focus)}',
             )
         )
         await ctx.send(embed=embed)
@@ -378,6 +379,36 @@ class Settings(AbstractCog):
 
         await ctx.send(embed=embed)
         self.journal.send("roles/jail", ctx.guild, content, icon="settings", role=role)
+    
+    @commands.command(name="setfocus")
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def set_focus_role(self, ctx, *, role: RoleConv = None):
+        """ Set the focus role for this guild. No argument to unset. """
+
+        logger.info(
+            "Setting focus role for guild '%s' (%d) to '%s'",
+            ctx.guild.name,
+            ctx.guild.id,
+            role,
+        )
+
+        if role is not None:
+            await self.check_role(ctx, role)
+
+        with self.bot.sql.transaction():
+            self.bot.sql.settings.set_special_roles(ctx.guild, focus=role)
+
+        embed = discord.Embed(colour=discord.Colour.green())
+        if role:
+            embed.description = f"Set focus role to {role.mention}"
+            content = f"Set the focus role to {role.mention}"
+        else:
+            embed.description = "Unset focus role"
+            content = "Unset the focus role"
+
+        await ctx.send(embed=embed)
+        self.journal.send("roles/focus", ctx.guild, content, icon="settings", role=role)
 
     @commands.group(name="reapply", aliases=["reapp"])
     @commands.guild_only()

--- a/futaba/emojis.py
+++ b/futaba/emojis.py
@@ -36,6 +36,7 @@ ICONS = {
     "muffled": "\N{FACE WITH MEDICAL MASK}",
     "mute": "\N{ZIPPER-MOUTH FACE}",
     "jail": "\N{POLICE OFFICER}",
+    "focus": "\N{BELL WITH CANCELLATION STROKE}",
     "shutdown": "\N{SKULL}",
     # Welcome / Roles
     "welcome": "\N{WAVING HAND SIGN}",

--- a/futaba/punishment.py
+++ b/futaba/punishment.py
@@ -99,6 +99,12 @@ class PunishmentHandler:
             "Jailing user '%s' (%d) for reason: %s", member.name, member.id, reason
         )
         await self.apply("jail", guild, member, reason)
+    
+    async def focus(self, guild, member, reason=None):
+        logger.info(
+            "Focusing user '%s' (%d) for reason: %s", member.name, member.id, reason
+        )
+        await self.apply("focus", guild, member, reason)
 
     async def unmute(self, guild, member, reason=None):
         logger.info(

--- a/futaba/sql/data/settings.py
+++ b/futaba/sql/data/settings.py
@@ -54,16 +54,17 @@ class ReapplyRolesData:
 
 
 class SpecialRoleData:
-    __slots__ = ("guild", "member_role", "guest_role", "mute_role", "jail_role")
+    __slots__ = ("guild", "member_role", "guest_role", "mute_role", "jail_role", "focus_role")
 
     def __init__(
-        self, guild, member_role_id, guest_role_id, mute_role_id, jail_role_id
+        self, guild, member_role_id, guest_role_id, mute_role_id, jail_role_id, focus_role_id
     ):
         self.guild = guild
         self.member_role = self._get_role(member_role_id)
         self.guest_role = self._get_role(guest_role_id)
         self.mute_role = self._get_role(mute_role_id)
         self.jail_role = self._get_role(jail_role_id)
+        self.focus_role = self._get_role(focus_role_id)
 
     def update(self, attrs):
         logger.debug("Updating special role storage: %s", attrs)
@@ -75,6 +76,8 @@ class SpecialRoleData:
             self.mute_role = attrs["mute"]
         if "jail" in attrs:
             self.jail_role = attrs["jail"]
+        if "focus" in attrs:
+            self.focus_role = attrs["focus"]
 
     @property
     def member(self):
@@ -91,6 +94,10 @@ class SpecialRoleData:
     @property
     def jail(self):
         return self.jail_role
+    
+    @property
+    def focus(self):
+        return self.focus_role
 
     def _get_role(self, id):
         if id is None:
@@ -103,6 +110,7 @@ class SpecialRoleData:
         yield self.guest_role
         yield self.mute_role
         yield self.jail_role
+        yield self.focus_role
 
 
 class TrackingBlacklistData:


### PR DESCRIPTION
Changed the way the focus (self jail) command works. Instead of applying the jail and mute roles, it will how apply a focus role allowing you to configure it differently on discord. This will stop users self jailing themselves to see what is happening in the channel used for talking to users that were jailed, as it was a common thing to happen.

This will still need tested as I am currently unable to do so.