### PR TITLE
Added check for a new special role to purge command

### DIFF
--- a/futaba/cogs/settings/core.py
+++ b/futaba/cogs/settings/core.py
@@ -409,6 +409,36 @@ class Settings(AbstractCog):
 
         await ctx.send(embed=embed)
         self.journal.send("roles/focus", ctx.guild, content, icon="settings", role=role)
+    
+    @commands.command(name="setnonpurge")
+    @commands.guild_only()
+    @permissions.check_mod()
+    async def set_nonpurge_role(self, ctx, *, role: RoleConv = None):
+        """ Set the nonpurge role for this guild. No argument to unset. """
+
+        logger.info(
+            "Setting nonpurge role for guild '%s' (%d) to '%s'",
+            ctx.guild.name,
+            ctx.guild.id,
+            role,
+        )
+
+        if role is not None:
+            await self.check_role(ctx, role)
+
+        with self.bot.sql.transaction():
+            self.bot.sql.settings.set_special_roles(ctx.guild, nonpurge=role)
+
+        embed = discord.Embed(colour=discord.Colour.green())
+        if role:
+            embed.description = f"Set nonpurge role to {role.mention}"
+            content = f"Set the nonpurge role to {role.mention}"
+        else:
+            embed.description = "Unset nonpurge role"
+            content = "Unset the nonpurge role"
+
+        await ctx.send(embed=embed)
+        self.journal.send("roles/nonpurge", ctx.guild, content, icon="settings", role=role)
 
     @commands.group(name="reapply", aliases=["reapp"])
     @commands.guild_only()

--- a/futaba/cogs/welcome/prune.py
+++ b/futaba/cogs/welcome/prune.py
@@ -88,7 +88,7 @@ class Prune(AbstractCog):
                     member,
                     prune_date,
                     has_roles={roles.guest},
-                    lacks_roles={roles.member, roles.mute, roles.jail},
+                    lacks_roles={roles.member, roles.mute, roles.jail, roles.nonpurge},
                 ),
                 ctx.guild.members,
             )
@@ -111,7 +111,7 @@ class Prune(AbstractCog):
                     member,
                     prune_date,
                     has_roles=(),
-                    lacks_roles={roles.member, roles.mute, roles.jail},
+                    lacks_roles={roles.member, roles.mute, roles.jail, roles.nonpurge},
                 ),
                 ctx.guild.members,
             )

--- a/futaba/sql/data/settings.py
+++ b/futaba/sql/data/settings.py
@@ -54,10 +54,10 @@ class ReapplyRolesData:
 
 
 class SpecialRoleData:
-    __slots__ = ("guild", "member_role", "guest_role", "mute_role", "jail_role", "focus_role")
+    __slots__ = ("guild", "member_role", "guest_role", "mute_role", "jail_role", "focus_role", "nonpurge_role")
 
     def __init__(
-        self, guild, member_role_id, guest_role_id, mute_role_id, jail_role_id, focus_role_id
+        self, guild, member_role_id, guest_role_id, mute_role_id, jail_role_id, focus_role_id, nonpurge_role_id
     ):
         self.guild = guild
         self.member_role = self._get_role(member_role_id)
@@ -65,6 +65,7 @@ class SpecialRoleData:
         self.mute_role = self._get_role(mute_role_id)
         self.jail_role = self._get_role(jail_role_id)
         self.focus_role = self._get_role(focus_role_id)
+        self.nonpurge_role = self._get_role(nonpurge_role_id)
 
     def update(self, attrs):
         logger.debug("Updating special role storage: %s", attrs)
@@ -78,6 +79,8 @@ class SpecialRoleData:
             self.jail_role = attrs["jail"]
         if "focus" in attrs:
             self.focus_role = attrs["focus"]
+        if "nonpurge" in attrs:
+            self.nonpurge_role = attrs["nonpurge"]
 
     @property
     def member(self):
@@ -94,10 +97,14 @@ class SpecialRoleData:
     @property
     def jail(self):
         return self.jail_role
-    
+
     @property
     def focus(self):
         return self.focus_role
+
+    @property
+    def nonpurge(self):
+        return self.nonpurge_role
 
     def _get_role(self, id):
         if id is None:
@@ -111,6 +118,7 @@ class SpecialRoleData:
         yield self.mute_role
         yield self.jail_role
         yield self.focus_role
+        yield self.nonpurge_role
 
 
 class TrackingBlacklistData:

--- a/futaba/sql/models/settings.py
+++ b/futaba/sql/models/settings.py
@@ -100,6 +100,7 @@ class SettingsModel:
             Column("mute_role_id", BigInteger, nullable=True),
             Column("jail_role_id", BigInteger, nullable=True),
             Column("focus_role_id", BigInteger, nullable=True),
+            Column("nonpurge_role_id", BigInteger, nullable=True),
             # Ensures special roles aren't assigned to @everyone
             CheckConstraint(
                 "member_role_id is NULL OR member_role_id != guild_id",
@@ -121,6 +122,10 @@ class SettingsModel:
                 "focus_role_id is NULL or focus_role_id != guild_id",
                 name="special_role_focus_not_everyone_check",
             ),
+            CheckConstraint(
+                "nonpurge_role_id is NULL or nonpurge_role_id != guild_id",
+                name="special_role_nonpurge_not_everyone_check",
+            ),
             # Ensures Guest and punishment roles aren't the same as the Member role
             CheckConstraint(
                 "guest_role_id is NULL OR guest_role_id != member_role_id",
@@ -137,6 +142,10 @@ class SettingsModel:
             CheckConstraint(
                 "focus_role_id is NULL OR focus_role_id != member_role_id",
                 name="special_role_focus_not_member_check",
+            ),
+            CheckConstraint(
+                "nonpurge_role_id is NULL OR nonpurge_role_id != member_role_id",
+                name="special_role_nonpurge_not_member_check",
             ),
         )
         self.tb_reapply_roles = Table(
@@ -355,6 +364,7 @@ class SettingsModel:
             mute_role_id=None,
             jail_role_id=None,
             focus_role_id=None,
+            nonpurge_role_id=None,
         )
         self.sql.execute(ins)
         self.special_roles_cache[guild] = SpecialRoleData(guild, None, None, None, None)
@@ -370,6 +380,7 @@ class SettingsModel:
                 self.tb_special_roles.c.mute_role_id,
                 self.tb_special_roles.c.jail_role_id,
                 self.tb_special_roles.c.focus_role_id,
+                self.tb_special_roles.c.nonpurge_role_id,
             ]
         ).where(self.tb_special_roles.c.guild_id == guild.id)
         result = self.sql.execute(sel)
@@ -378,9 +389,9 @@ class SettingsModel:
             self.add_special_roles(guild)
             return self.special_roles_cache[guild]
 
-        member_role_id, guest_role_id, mute_role_id, jail_role_id, focus_role_id = result.fetchone()
+        member_role_id, guest_role_id, mute_role_id, jail_role_id, focus_role_id, nonpurge_role_id = result.fetchone()
         roles = SpecialRoleData(
-            guild, member_role_id, guest_role_id, mute_role_id, jail_role_id, focus_role_id
+            guild, member_role_id, guest_role_id, mute_role_id, jail_role_id, focus_role_id, nonpurge_role_id
         )
         self.special_roles_cache[guild] = roles
         return roles
@@ -391,7 +402,7 @@ class SettingsModel:
 
         values = {}
         for attr, role in attrs.items():
-            assert attr in ("member", "guest", "mute", "jail", "focus"), "Unknown column"
+            assert attr in ("member", "guest", "mute", "jail", "focus", "nonpurge"), "Unknown column"
             values[f"{attr}_role_id"] = getattr(role, "id", None)
 
         upd = (


### PR DESCRIPTION
Added a new special role to guild settings to make a user immune to a bot purge.
Purge will now check if the user does not have the nonpurge role before purging
The role can be configured using `!setnonpurge <role>`

Before this PR goes live an update to the postgres DB will need to be done to add a column to the table for this new setting.
`ALTER TABLE special_roles ADD COLUMN nonpurge_role_id bigint`