### PR TITLE
Prevent attempts at nesting character sets in regex filter

### DIFF
--- a/futaba/cogs/filter/filter.py
+++ b/futaba/cogs/filter/filter.py
@@ -104,31 +104,53 @@ class Filter:
         return str(pattern)
 
     @staticmethod
+    def generate_confusable_literals(confusable: chr) -> list:
+        # Generates list of confusable homoglyphs LITERALs based on input
+        # character, includes input character
+
+        groups = confusables.is_confusable(confusable, greedy=True)
+
+        confusable_literals = [(sre_parse.LITERAL, ord(confusable))]
+
+        if not groups:
+            return confusable_literals
+
+        # Append confusables to list as LITERALs
+        for homoglyph in groups[0]["homoglyphs"]:
+            confusable_literals += [
+                (re.sre_parse.LITERAL, ord(char)) for char in homoglyph["c"]
+            ]
+
+        return confusable_literals
+
+    @staticmethod
     def convert_raw_regex_ast(regex_ast: Iterable):
         for index, value in enumerate(regex_ast):
-            # Parse lexemes for LITERALs
             if isinstance(value, tuple):
-                lexeme_tuple = value
-                if lexeme_tuple[0] == sre_parse.LITERAL:
-                    # LITERAL found, check if it's a confusable homoglyph...
-                    groups = confusables.is_confusable(
-                        chr(lexeme_tuple[1]), greedy=True
+                # (TOKEN_NAME, TOKEN_VALUE) likely
+                (
+                    token_name,
+                    token_value,
+                    *_,
+                ) = value
+                if token_name == sre_parse.IN:
+                    # (IN, [ (LITERAL, ord) ... ])
+                    # sets cannot be nested, need to insert confusables in place
+                    confusable_literals = []
+                    for literal in token_value:
+                        confusable_literals += Filter.generate_confusable_literals(
+                            chr(literal[1])
+                        )
+                    token_value += confusable_literals
+                if token_name == sre_parse.LITERAL:
+                    # (LITERAL, ord), replace with set
+                    confusable_literals = Filter.generate_confusable_literals(
+                        chr(token_value)
                     )
-                    if not groups:
-                        continue
-                    # Convert group into list of confusable LITERALs
-                    group = groups[0]  # one char, so only one group
-                    confusable_literals = [lexeme_tuple]
-                    for homoglyph in group["homoglyphs"]:
-                        confusable_literals += [
-                            (sre_parse.LITERAL, ord(char)) for char in homoglyph["c"]
-                        ]
-                    in_lexeme_tuple = (sre_parse.IN, confusable_literals)
-
-                    # Overwrite this lexeme
-                    regex_ast[index] = in_lexeme_tuple
+                    regex_ast[index] = (sre_parse.IN, confusable_literals)
                 else:
-                    # More possible lexemes, recurse and overwrite...
+                    # Miscellaneous token, might contain more tokens
+                    # Recurse and overwrite...
                     regex_ast[index] = tuple(Filter.convert_raw_regex_ast(list(value)))
             elif isinstance(value, sre_parse.SubPattern):
                 regex_ast[index] = Filter.convert_raw_regex_ast(value)


### PR DESCRIPTION
Not sure how I didn't catch this when testing the initial regex feature a couple years ago. Basically, nesting character sets is impossible in Python's regex, which is what my filter code tried to do because it wasn't checking for IN tokens, so those confusable glyphs would be discarded by the regex compiler (thankfully it doesn't outright throw an error). This PR adds that check and performs confusable insertion in place for those sets. Also cleans up some of the code in that area.

Example of the issue:
`h[ea]lp` would effectively be converted into this, which is invalid regex:
```
[hｈℎ𝐡𝒉𝒽𝓱𝔥𝕙𝖍𝗁𝗵𝘩𝙝𝚑һհᏂ]**[**[e℮ｅℯⅇ𝐞𝑒𝒆𝓮𝔢𝕖𝖊𝖾𝗲𝘦𝙚𝚎ꬲеҽ][a⍺ａ𝐚𝑎𝒂𝒶𝓪𝔞𝕒𝖆𝖺𝗮𝘢𝙖𝚊ɑα𝛂𝛼𝜶𝝰𝞪а]**]**[l𝟏𝟙𝟣𝟭𝟷IＩⅠℐℑ𝐈𝐼𝑰𝓘𝕀𝕴𝖨𝗜𝘐𝙄𝙸Ɩｌⅼℓ𝐥𝑙𝒍𝓁𝓵𝔩𝕝𝖑𝗅𝗹𝘭𝙡𝚕ǀΙ𝚰𝛪𝜤𝝞𝞘ⲒІӀⵏᛁꓲ𖼨𐊊𐌉][p⍴ｐ𝐩𝑝𝒑𝓅𝓹𝔭𝕡𝖕𝗉𝗽𝘱𝙥𝚙ρϱ𝛒𝛠𝜌𝜚𝝆𝝔𝞀𝞎𝞺𝟈ⲣр]
```
instead of this, which is valid and desired:
```
[hｈℎ𝐡𝒉𝒽𝓱𝔥𝕙𝖍𝗁𝗵𝘩𝙝𝚑һհᏂ]**[**e℮ｅℯⅇ𝐞𝑒𝒆𝓮𝔢𝕖𝖊𝖾𝗲𝘦𝙚𝚎ꬲеҽa⍺ａ𝐚𝑎𝒂𝒶𝓪𝔞𝕒𝖆𝖺𝗮𝘢𝙖𝚊ɑα𝛂𝛼𝜶𝝰𝞪а**]**[l𝟏𝟙𝟣𝟭𝟷IＩⅠℐℑ𝐈𝐼𝑰𝓘𝕀𝕴𝖨𝗜𝘐𝙄𝙸Ɩｌⅼℓ𝐥𝑙𝒍𝓁𝓵𝔩𝕝𝖑𝗅𝗹𝘭𝙡𝚕ǀΙ𝚰𝛪𝜤𝝞𝞘ⲒІӀⵏᛁꓲ𖼨𐊊𐌉][p⍴ｐ𝐩𝑝𝒑𝓅𝓹𝔭𝕡𝖕𝗉𝗽𝘱𝙥𝚙ρϱ𝛒𝛠𝜌𝜚𝝆𝝔𝞀𝞎𝞺𝟈ⲣр]
```
(\*\* only added for emphasis)